### PR TITLE
feat(scaffold): typed-query-selectorの追加

### DIFF
--- a/packages/@d-zero/scaffold/__assets/_libs/script/index.ts
+++ b/packages/@d-zero/scaffold/__assets/_libs/script/index.ts
@@ -1,3 +1,6 @@
+// querySelector() または querySelectorAll() を実行する場合、次の import 文を有効にしてください。
+// import 'typed-query-selector/strict.js';
+
 export function helloWorld() {
 	console.log('Hello, world!'); // eslint-disable-line no-console
 }

--- a/packages/@d-zero/scaffold/__assets/_libs/script/index.ts
+++ b/packages/@d-zero/scaffold/__assets/_libs/script/index.ts
@@ -1,5 +1,4 @@
-// querySelector() または querySelectorAll() を実行する場合、次の import 文を有効にしてください。
-// import 'typed-query-selector/strict.js';
+import 'typed-query-selector/strict.js';
 
 export function helloWorld() {
 	console.log('Hello, world!'); // eslint-disable-line no-console

--- a/packages/@d-zero/scaffold/package.json
+++ b/packages/@d-zero/scaffold/package.json
@@ -41,6 +41,7 @@
 		"cross-env": "7.0.3",
 		"npm-run-all2": "6.2.0",
 		"sass": "1.77.5",
+		"typed-query-selector": "2.11.2",
 		"typescript": "5.4.5"
 	},
 	"dependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -11797,6 +11797,11 @@ typed-function@0.10.7:
   resolved "https://registry.yarnpkg.com/typed-function/-/typed-function-0.10.7.tgz#f702af7d77a64b61abf86799ff2d74266ebc4477"
   integrity sha512-3mlZ5AwRMbLvUKkc8a1TI4RUJUS2H27pmD5q0lHRObgsoWzhDAX01yg82kwSP1FUw922/4Y9ZliIEh0qJZcz+g==
 
+typed-query-selector@2.11.2:
+  version "2.11.2"
+  resolved "https://registry.yarnpkg.com/typed-query-selector/-/typed-query-selector-2.11.2.tgz#30f9a2d7d51fc08781b277dff91c61aa8dd756c3"
+  integrity sha512-6rZP+cG3wPg2w1Zqv2VCOsSqlkGElrLSGeEkyrIU9mHG+JfQZE/6lE3oyQouz42sTS9n8fQXvwQBaVWz6dzpfQ==
+
 typedarray.prototype.slice@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/typedarray.prototype.slice/-/typedarray.prototype.slice-1.0.3.tgz#bce2f685d3279f543239e4d595e0d021731d2d1a"


### PR DESCRIPTION
scaffold に typed-query-selector を追加しました。

`querySelector()` または `querySelectorAll()` に不正な文字列を指定した場合、`never` 型になる strict モードのインポートを推奨しています。
https://github.com/g-plane/typed-query-selector?tab=readme-ov-file#strict-mode

close #50 
