### PR TITLE
feat(builder): css,js,画像ファイルのアウトプット先ディレクトリを指定できるようにする

### DIFF
--- a/packages/@d-zero/builder/eleventy.config.cjs
+++ b/packages/@d-zero/builder/eleventy.config.cjs
@@ -12,6 +12,9 @@ const { INLINE_SCRIPT_FILE_DELETE_ID } = require('./const.cjs');
  */
 module.exports = function (eleventyConfig) {
 	const isServe = process.env.NODE_ENV === 'serve';
+	const outputCssDir = eleventyConfig.globalData.outputCssDir ?? 'css';
+	const outputJsDir = eleventyConfig.globalData.outputJsDir ?? 'js';
+	const outputImgDir = eleventyConfig.globalData.outputImgDir ?? 'img';
 
 	global.filters = eleventyConfig.javascriptFunctions;
 
@@ -70,11 +73,11 @@ module.exports = function (eleventyConfig) {
 					output: {
 						assetFileNames: ({ name }) => {
 							if (name.endsWith('.css')) {
-								return `css/${name}`;
+								return `${outputCssDir}/${name}`;
 							}
-							return `img/${name}`;
+							return `${outputImgDir}/${name}`;
 						},
-						chunkFileNames: () => 'js/[name].js',
+						chunkFileNames: () => `${outputJsDir}/[name].js`,
 						entryFileNames: () => INLINE_SCRIPT_FILE_DELETE_ID,
 					},
 				},
@@ -94,6 +97,9 @@ module.exports = function (eleventyConfig) {
 			output: isServe ? '.serve' : 'htdocs',
 			layouts: '../_libs/component',
 			data: '../_libs/data',
+			outputCss: outputCssDir,
+			outputJs: outputJsDir,
+			outputImg: outputImgDir,
 		},
 	};
 };

--- a/packages/@d-zero/builder/fn/build.mjs
+++ b/packages/@d-zero/builder/fn/build.mjs
@@ -22,12 +22,14 @@ export async function build(elev) {
 	const options = elev.config?.globalData ?? {};
 	const outDir = elev.config.dir.output;
 
-	const cssFiles = await glob(path.resolve(elev.config.dir.input, 'css', '**', '*.scss'));
+	const cssFiles = await glob(
+		path.resolve(elev.config.dir.input, elev.config.dir.outputCss, '**', '*.scss'),
+	);
 	for (const file of cssFiles) {
 		const name = path.basename(file, path.extname(file));
 		const out = await buildCss(
 			file,
-			path.resolve(elev.config.dir.output, 'css', `${name}.css`),
+			path.resolve(elev.config.dir.output, elev.config.dir.outputCss, `${name}.css`),
 			options,
 		);
 	}

--- a/packages/@d-zero/scaffold/eleventy.config.cjs
+++ b/packages/@d-zero/scaffold/eleventy.config.cjs
@@ -4,6 +4,9 @@ const eleventy = require('@d-zero/builder/11ty');
 
 module.exports = function (eleventyConfig) {
 	// eleventyConfig.addGlobalData('publicDir', '@static');
+	// eleventyConfig.addGlobalData('outputCssDir', 'css');
+	// eleventyConfig.addGlobalData('outputJsDir', 'js');
+	// eleventyConfig.addGlobalData('outputImgDir', 'img');
 
 	eleventyConfig.addGlobalData('alias', {
 		'@': path.resolve(__dirname, '__assets', '_libs'),


### PR DESCRIPTION
[eleventy.config.cjs](https://github.com/d-zero-dev/frontend-env/commit/bd6028b501c872e5667878b754f48938db39e130#diff-0e42dc786f71d1cf3870005900d9375a3ab0e8138ffbd94d163f2b486ff75f28)でcss,js,画像ファイルのアウトプット先を`globalData`で指定できるようにしています。