### PR TITLE
feat(builder): html-minifier-terserで設定したhtmlの変換をローカルサーバーでも確認できるようにする

### DIFF
--- a/packages/@d-zero/builder/eleventy.config.cjs
+++ b/packages/@d-zero/builder/eleventy.config.cjs
@@ -2,6 +2,7 @@ const path = require('node:path');
 
 const EleventyVitePlugin = require('@11ty/eleventy-plugin-vite');
 const dayjs = require('dayjs');
+const htmlmin = require('html-minifier-terser');
 const yaml = require('js-yaml');
 
 const { INLINE_SCRIPT_FILE_DELETE_ID } = require('./const.cjs');
@@ -33,6 +34,14 @@ module.exports = function (eleventyConfig) {
 		minifyCSS: true,
 		minifyJS: true,
 		...eleventyConfig.globalData.minifier,
+	});
+
+	eleventyConfig.addTransform('htmlmin', function (content) {
+		if ((this.page.outputPath || '').endsWith('.html')) {
+			return htmlmin.minify(content, eleventyConfig.globalData.minifier);
+		}
+
+		return content;
 	});
 
 	eleventyConfig.setPugOptions({


### PR DESCRIPTION
html-minifier-terserでのhtmlの変換がbuildした後のコードでしか確認できない状態だったので、調整しています。

`input[type="text"]`は[html-minifier-terser](https://github.com/terser/html-minifier-terser?tab=readme-ov-file#options-quick-reference)の`removeRedundantAttributes`を`true`にするとtype属性が削除されますが、
`yarn dev`で立てたローカルサーバーで確認すると`type="text"`が残ったままになっていました

参考：https://www.11ty.dev/docs/transforms/#minify-html-output