### PR TITLE
fix(scaffold): add dotenv

### DIFF
--- a/packages/@d-zero/scaffold/package.json
+++ b/packages/@d-zero/scaffold/package.json
@@ -46,6 +46,7 @@
 		"@d-zero/tsconfig": "0.5.0",
 		"@types/node": "22.17.2",
 		"cross-env": "10.0.0",
+		"dotenv": "17.2.1",
 		"husky": "9.1.7",
 		"npm-run-all2": "8.0.4",
 		"typescript": "5.9.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1338,6 +1338,7 @@ __metadata:
     "@types/node": "npm:22.17.2"
     cross-env: "npm:10.0.0"
     dialog-toggle-events-polyfill: "npm:1.1.4"
+    dotenv: "npm:17.2.1"
     husky: "npm:9.1.7"
     invokers-polyfill: "npm:0.5.6"
     kiso.css: "npm:1.2.2"
@@ -7350,6 +7351,13 @@ __metadata:
   dependencies:
     dotenv: "npm:^16.4.5"
   checksum: 10c0/d80b8a7be085edf351270b96ac0e794bc3ddd7f36157912939577cb4d33ba6492ebee349d59798b71b90e36f498d24a2a564fb4aa00073b2ef4c2a3a49c467b1
+  languageName: node
+  linkType: hard
+
+"dotenv@npm:17.2.1":
+  version: 17.2.1
+  resolution: "dotenv@npm:17.2.1"
+  checksum: 10c0/918dd2f9d8b8f86b0afabad9534793d51de3718c437f9e7b6525628cf68c1d4ae768cc37a5afff38c066f58a8ecf549f4ac6cd5617485bd328e826112cc2650a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
`npx @d-zero/create-frontend`で開発環境をダウンロードした後、yarn bgeを実行すると下記エラーが出たため、scaffoldの方でも明示的にdotenvを追加しました。

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'dotenv' imported from **
```