### PR TITLE
CSSのminifyを行わない場合、整形ルールを上書きできるようにする。

### DIFF
--- a/packages/@d-zero/builder/src/eleventy-plugins/style.ts
+++ b/packages/@d-zero/builder/src/eleventy-plugins/style.ts
@@ -34,7 +34,8 @@ export const stylePlugin: EleventyPlugin<StylePluginConfig, EleventyGlobalData> 
 				});
 
 				if (!cssMinify) {
-					content = await prettifyCss(content);
+					const prettierOptions = pluginConfig.prettier ?? false;
+					content = await prettifyCss(content, inputPath, prettierOptions);
 				}
 
 				return `${pluginConfig.banner}\n${content}`;
@@ -57,7 +58,8 @@ export const stylePlugin: EleventyPlugin<StylePluginConfig, EleventyGlobalData> 
 				});
 
 				if (!cssMinify) {
-					content = await prettifyCss(content);
+					const prettierOptions = pluginConfig.prettier ?? false;
+					content = await prettifyCss(content, inputPath, prettierOptions);
 				}
 
 				return `${pluginConfig.banner}\n${content}`;
@@ -76,12 +78,22 @@ export const stylePlugin: EleventyPlugin<StylePluginConfig, EleventyGlobalData> 
 /**
  *
  * @param content
+ * @param inputPath
+ * @param prettierOptions
  */
-async function prettifyCss(content: string) {
+async function prettifyCss(
+	content: string,
+	inputPath: string,
+	prettierOptions: PrettierOptions | boolean,
+) {
 	const prettier = await import('prettier');
+	const options = typeof prettierOptions === 'object' ? prettierOptions : {};
+	const config = await prettier.resolveConfig(inputPath);
 	return await prettier.format(content, {
 		parser: 'css',
 		tabWidth: 2,
 		useTabs: false,
+		...options,
+		...config,
 	});
 }


### PR DESCRIPTION
Fixes #643

## 補足

参考にしたHTMLのプラグインを改めて見返すと、prettierの設定の優先度が

1. prettierのオプションファイル（最後に記載されているため最優先で適応される）
2. eleventyの設定ファイル
3. builder内での設定

になっていたので、1と2の順序が適切かは別途要検討