### PR TITLE
fix(builder): correct output path extension to .html in html plugin

### DIFF
--- a/packages/@d-zero/builder/src/eleventy-plugins/html.ts
+++ b/packages/@d-zero/builder/src/eleventy-plugins/html.ts
@@ -52,7 +52,10 @@ export const htmlPlugin: EleventyPlugin<HtmlPluginOptions, EleventyGlobalData> =
 		const outputPath =
 			'/' +
 			path
-				.relative(path.join(process.cwd(), eleventyConfig.dir.input), transferred)
+				.relative(
+					path.join(process.cwd(), eleventyConfig.dir.input),
+					path.format({ ...path.parse(transferred), base: '', ext: '.html' }),
+				)
 				.replaceAll(path.sep, '/');
 
 		const imageSizesOptions = pluginConfig?.imageSizes ?? true;


### PR DESCRIPTION
HTMLのプラグインにて、outputPathの値のファイル拡張子が入力側のものになっていたため（例えば`.pug`）`.html`となるように修正しました。

これによって、charsetオプションのoverridesに入れたファイルパスが正しく認識されず、ビルド後の文字コードが指定したものにならない問題が発生していました。