### PR TITLE
test(create-frontend): use createHash instead of encodeURIComponent for test directory names

### DIFF
--- a/packages/@d-zero/create-frontend/index.spec.js
+++ b/packages/@d-zero/create-frontend/index.spec.js
@@ -11,7 +11,7 @@ import { describe, test, expect, beforeEach } from 'vitest';
  * @param task
  */
 function getName(task) {
-	return createHash('sha256').update(`${task.suite.name}${task.name}`).digest('hex');
+	return createHash('sha256').update(`${task.suite.name}_${task.name}`).digest('hex');
 }
 
 beforeEach((ctx) => {


### PR DESCRIPTION
GitHub Actionsでのテスト失敗を修正するため、テストディレクトリ名の生成方法を`encodeURIComponent`から`createHash`に変更しました。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates test utilities to avoid problematic directory names.
> 
> - Replace `encodeURIComponent` in `getName` with `createHash('sha256')` of `${task.suite.name}${task.name}` to generate temp directory names
> - Add `node:crypto` import; no changes to production code or CLI behavior
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b3a96e1c8ca31ddb455436eddd6243e461b6681b. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->