### PR TITLE
fix: change prepare to postinstall for Yarn v4 compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
 		"release:alpha:latest": "lerna publish --exact --force-publish --conventional-commits --conventional-prerelease --preid alpha",
 		"release:beta:latest": "lerna publish --exact --force-publish --conventional-commits --conventional-prerelease --preid beta",
 		"release:next": "lerna publish --dist-tag next --exact --force-publish --conventional-commits --conventional-prerelease --preid alpha",
-		"prepare": "husky",
+		"postinstall": "husky",
 		"commit": "npx cz",
 		"co": "npx cz",
 		"update": "yarn upgrade-interactive"


### PR DESCRIPTION
Fixes #766

## 問題

Yarn v4環境では`prepare`ライフサイクルスクリプトが`yarn install`時に自動実行されないため、Huskyのフックが初期化されない問題が発生していました。

チームメンバーは`.husky/_`ディレクトリを生成するために手動で`yarn prepare`を実行する必要があり、自動セットアップの目的が損なわれていた。

## 原因

Yarn v4は[意図的に](https://yarnpkg.com/advanced/lifecycle-scripts)、ユーザー定義スクリプトに対する任意の`pre`/`post`フックをサポートしていません：

> "we intentionally don't support arbitrary pre and post hooks for user-defined scripts (such as prestart). This behavior caused scripts to be implicit rather than explicit, obfuscating the execution flow."
> （実行フローを明示的にするため、`prestart`のようなユーザー定義スクリプトに対する任意のpre/postフックを意図的にサポートしていません。この動作はスクリプトを暗黙的にし、実行フローを不明瞭にしていました）

## 解決策

`prepare`から、Yarn v4で公式にサポートされているライフサイクルスクリプトである`postinstall`に変更しました。

## 動作確認

- ✅ Yarn v4環境で`yarn install`実行後に`postinstall`が正常に実行されることを確認
- ✅ `.husky/_`ディレクトリが自動生成されることを確認
- ✅ 手動での`yarn prepare`実行が不要になったことを確認