### PR TITLE
fix: use url constant in meta.pug

### DIFF
--- a/packages/@d-zero/scaffold/__assets/_libs/mixin/meta.pug
+++ b/packages/@d-zero/scaffold/__assets/_libs/mixin/meta.pug
@@ -11,10 +11,10 @@ if pkg.production.siteName
 if ogDescription || description
 	meta(property="og:description" content=ogDescription || description || "")
 if pkg.production.host
-	meta(property="og:url" content=pkg.production.host + page.url)
+	meta(property="og:url" content=url)
 	meta(property="og:image" content=pkg.production.host + (ogImage || "/img/ogp.png"))
 meta(name="twitter:card" content=ogCard || "summary_large_image")
-meta(name="twitter:url" content=pkg.production.host + page.url)
+meta(name="twitter:url" content=url)
 if pkg.production.siteName
 	meta(name="twitter:title" content=pkg.production.siteName || "__サイト名__")
 if ogDescription || description


### PR DESCRIPTION
## 概要
   meta.pugで先頭に定義されている`url`定数が使用されておらず、代わりに`pkg.production.host + page.url`がハードコードされていたため、定数を使用するように修正しました。

   ## 変更内容
   - 14行目: `og:url`のcontentで`url`定数を使用
   - 17行目: `twitter:url`のcontentで`url`定数を使用

   ## 理由
   - DRY原則に従い、重複を排除
   - 既に定義されている定数を活用
   - 将来的な変更が容易になる