### PR TITLE
chore(repo): use Takumi Guard registry proxy

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,3 +1,3 @@
 nodeLinker: node-modules
-npmRegistryServer: 'https://registry.npmjs.org'
+npmRegistryServer: 'https://npm.flatt.tech/'
 enableGlobalCache: true

--- a/packages/@d-zero/scaffold/.yarnrc.yml
+++ b/packages/@d-zero/scaffold/.yarnrc.yml
@@ -1,3 +1,3 @@
 nodeLinker: node-modules
-npmRegistryServer: 'https://registry.npmjs.org'
+npmRegistryServer: 'https://npm.flatt.tech/'
 enableGlobalCache: true


### PR DESCRIPTION
## Summary

- npmレジストリを [Takumi Guard](https://shisho.dev/docs/ja/t/guard/quickstart/npm) のプロキシ (`https://npm.flatt.tech/`) に変更
- ルートおよび `packages/@d-zero/scaffold` の `.yarnrc.yml` を更新
- サプライチェーン攻撃対策として、悪意あるパッケージのブロック・ダウンロード追跡・脆弱性通知が有効化される

## Test plan

- [ ] `yarn install` が正常に完了すること
- [ ] パッケージの解決先が Takumi Guard プロキシ経由になっていること

🤖 Generated with [Claude Code](https://claude.com/claude-code)