### PR TITLE
feat(site-migrator): strip shared layouts from archive page snapshots

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,7 @@ yarn-error.log
 # claude
 .claude/*.local.*
 *.nitpicker
+
+# codex / other agent runtimes
+.agents/
+AGENTS.md

--- a/.textlintignore
+++ b/.textlintignore
@@ -1,5 +1,7 @@
 CHANGELOG.md
 **/CHANGELOG.md
 .agent/**/*
+.agents/**/*
+AGENTS.md
 .claude/**/*
 .cursor/**/*

--- a/packages/@d-zero/site-migrator/README.md
+++ b/packages/@d-zero/site-migrator/README.md
@@ -1,6 +1,6 @@
 # `@d-zero/site-migrator`
 
-`.nitpicker` アーカイブを入力とするウェブサイト移植ツールキット。サブリソースをローカルへ DL する CLI と、後続の変換処理で使うユーティリティ関数群を提供する。
+`.nitpicker` アーカイブを入力とするウェブサイト移植ツールキット。サブリソースのローカル DL とページ HTML のレイアウト剥がしを行う CLI、および後続の変換処理で使うユーティリティ関数群を提供する。
 
 ## Installation
 
@@ -11,14 +11,15 @@ yarn add @d-zero/site-migrator
 ## CLI
 
 ```sh
-npx dz-migrate <archive.nitpicker> -o <htdocs-dir> [--limit <n>]
+npx dz-migrate <archive.nitpicker> -o <htdocs-dir> [--limit <n>] [--extract-limit <n>]
 ```
 
 - `<archive.nitpicker>` — [nitpicker](https://github.com/d-zero-dev/nitpicker) で生成済みのアーカイブファイル
-- `-o, --output <htdocs-dir>` — リソース DL 先。URL の pathname をそのままミラーする（例: `https://example.com/img/a.png` → `<htdocs-dir>/img/a.png`）
+- `-o, --output <htdocs-dir>` — 出力先。URL の pathname をそのままミラーする（例: `https://example.com/img/a.png` → `<htdocs-dir>/img/a.png`、`https://example.com/about/` → `<htdocs-dir>/about/index.html`）
 - `--limit <n>` — 並列 DL 数（デフォルト 10）
+- `--extract-limit <n>` — 並列ページ抽出数（デフォルト 10）
 
-`.nitpicker` 内に格納された HTML スナップショットはディスクには落とさない（原本は `.nitpicker` が保持する）。HTML を扱う後続処理は本パッケージの API を経由して on-demand に取得する。
+リソースは fetch で DL、ページ HTML はアーカイブ内のスナップショットを読み、`extractMainContent` でレイアウト共通部分を剥がしてから `.html` として書き出す。
 
 ## Programmatic API
 
@@ -33,25 +34,50 @@ import {
 	urlToOutputPath,
 	rewriteAssetRefs,
 	extractFrontmatter,
+	extractMainContent,
+	extractPages,
 } from '@d-zero/site-migrator';
 ```
 
 主要 API:
 
-| 関数                    | 概要                                                        |
-| ----------------------- | ----------------------------------------------------------- |
-| `migrate`               | アーカイブを開き、リソースを並列 DL する CLI のロジック本体 |
-| `openArchive`           | `.nitpicker` を開いてセッションを返す（要 `close()`）       |
-| `listInternalPages`     | 内部ページ URL を順に yield する非同期イテラブル            |
-| `listInternalResources` | 内部リソース URL を順に yield する非同期イテラブル          |
-| `getPageHtml`           | レンダリング後 HTML を全長で取得（truncate なし）           |
-| `downloadResources`     | URL リストを並列 fetch してローカルへ保存                   |
-| `urlToOutputPath`       | URL を `<htdocs-dir>` 配下のローカルパスへ変換              |
-| `rewriteAssetRefs`      | HTML 内のアセット参照を resolver で書き換える（streaming）  |
-| `extractFrontmatter`    | `<head>` のメタ情報を構造化オブジェクトへ抽出               |
+| 関数                    | 概要                                                               |
+| ----------------------- | ------------------------------------------------------------------ |
+| `migrate`               | アーカイブを開き、リソース DL とページ抽出を並列実行する全体フロー |
+| `openArchive`           | `.nitpicker` を開いてセッションを返す（要 `close()`）              |
+| `listInternalPages`     | 内部ページ URL を順に yield する非同期イテラブル                   |
+| `listInternalResources` | 内部リソース URL を順に yield する非同期イテラブル                 |
+| `getPageHtml`           | レンダリング後 HTML を全長で取得（truncate なし）                  |
+| `downloadResources`     | URL リストを並列 fetch してローカルへ保存                          |
+| `urlToOutputPath`       | URL を `<htdocs-dir>` 配下のローカルパスへ変換                     |
+| `rewriteAssetRefs`      | HTML 内のアセット参照を resolver で書き換える（streaming）         |
+| `extractFrontmatter`    | `<head>` のメタ情報を構造化オブジェクトへ抽出                      |
+| `extractMainContent`    | レイアウト共通部分を剥がして本文要素の `outerHTML` を返す          |
+| `extractPages`          | ページ一覧に対して `extractMainContent` を並列適用して書き出す     |
 
 `extractFrontmatter` の出力構造は [`Frontmatter`](./src/types.ts) を参照。`title` / `og.title` / `twitter.title` は `｜` `|` で分割して最初の非空セグメントを採用し、raw と異なる場合のみ `rawTitle` 等に raw を保持する。
 
+### `extractMainContent` のヒューリスティクス
+
+精緻な構造推論はせず、以下の優先順位で「ページ内にちょうど 1 個だけ存在する」要素を本文として採用する。
+
+1. `class` のトークンに `main` を含む
+2. `class` のトークンに `content` を含む
+3. `<main>` 要素
+4. `role="main"` を持つ要素
+5. `id` に `main` を含む
+6. `id` に `content` を含む
+
+各段で 0 個または 2 個以上だった場合は次の段へフォールスルー。6 段すべてで満たさなかった場合は `matched: false` として元の HTML をそのまま返すので、呼び出し側はファイル出力時に空にはならない。マッチ確定後は `serializeOuter` で抽出要素のタグごとフラグメント（DOCTYPE / `<html>` / `<head>` を含まない）を返す。
+
+クラス / ID の判定は大小無視。クラスは whitespace で分割したトークン内の substring 一致（`page-main` は OK だが `domain` のような偽陽性は実用上ほぼ起きない前提）。`role` 属性は WAI-ARIA に従い whitespace 区切りのトークンリストとして扱い、トークンのいずれかが `main` に等しければマッチ。`<html>` / `<head>` / `<body>` は候補から除外しているため `<body class="main">` がページ全体を吸い込む事故は起きない。
+
+#### 既知の制限
+
+- 同一トークン substring の副作用: `class="sitemap-main-link"` のように `main` を含むトークンを持つ要素が複数あると rung 1 が「2 個以上」で失格しフォールスルーする。雑な実装の代償として許容。
+- ページ URL が `outputDir` 配下で衝突する場合（例: `/about/` と `/about/index.html` が両方ページとして登録されている）、2 つ目以降は `failed` として報告し書き込まない。
+- リソース URL とページ URL が衝突した場合は、ページ書き出しが後勝ちで上書きする（レイアウト剥がし後の HTML を canonical 版とみなすため）。
+
 ## 設計上の注意
 
-`extractFrontmatter` と `rewriteAssetRefs` は parse5 を内部で使うが、外部 API としては「HTML 文字列 → 構造化データ／HTML 文字列」の純関数。将来 nitpicker がメタを DB カラムとして保持した場合に差し替えやすいよう、parse5 に依存するコードは `src/html/` 配下に閉じている。
+`extractFrontmatter` / `rewriteAssetRefs` / `extractMainContent` は parse5 を内部で使うが、外部 API としては「HTML 文字列 → 構造化データ／HTML 文字列」の純関数。将来 nitpicker がメタを DB カラムとして保持した場合などに差し替えやすいよう、parse5 に依存するコードは `src/html/` 配下に閉じている。

--- a/packages/@d-zero/site-migrator/src/cli.ts
+++ b/packages/@d-zero/site-migrator/src/cli.ts
@@ -4,12 +4,14 @@ import { parseArgs } from 'node:util';
 import { migrate } from './migrate.js';
 
 const USAGE = `Usage:
-  dz-migrate <archive.nitpicker> -o <htdocs-dir> [--limit <n>]
+  dz-migrate <archive.nitpicker> -o <htdocs-dir> [--limit <n>] [--extract-limit <n>]
 
 Options:
-  -o, --output <htdocs-dir>   Resource download destination. URL pathnames are mirrored verbatim.
-  --limit <n>                 Concurrent download limit (default: 10).
-  -h, --help                  Show this help message.
+  -o, --output <htdocs-dir>      Output destination. URL pathnames are mirrored verbatim
+                                 for both downloaded resources and extracted page HTML.
+  --limit <n>                    Concurrent resource download limit (default: 10).
+  --extract-limit <n>            Concurrent page extraction limit (default: 10).
+  -h, --help                     Show this help message.
 `;
 
 /**
@@ -26,6 +28,7 @@ async function main(argv: readonly string[]): Promise<number> {
 			options: {
 				output: { type: 'string', short: 'o' },
 				limit: { type: 'string' },
+				'extract-limit': { type: 'string' },
 				help: { type: 'boolean', short: 'h', default: false },
 			},
 		});
@@ -57,19 +60,18 @@ async function main(argv: readonly string[]): Promise<number> {
 		return 2;
 	}
 
-	let downloadLimit: number | undefined;
-	if (parsed.values.limit !== undefined) {
-		// Reject decimals, trailing garbage ("10abc"), scientific notation,
-		// and signs — parseInt is too lenient for CLI input.
-		if (!/^\d+$/.test(parsed.values.limit)) {
-			process.stderr.write(`Error: --limit must be a positive integer\n`);
-			return 2;
-		}
-		downloadLimit = Number.parseInt(parsed.values.limit, 10);
-		if (downloadLimit < 1) {
-			process.stderr.write(`Error: --limit must be a positive integer\n`);
-			return 2;
-		}
+	const downloadLimit = parsePositiveInt(parsed.values.limit, '--limit');
+	if (downloadLimit instanceof Error) {
+		process.stderr.write(`Error: ${downloadLimit.message}\n`);
+		return 2;
+	}
+	const extractLimit = parsePositiveInt(
+		parsed.values['extract-limit'],
+		'--extract-limit',
+	);
+	if (extractLimit instanceof Error) {
+		process.stderr.write(`Error: ${extractLimit.message}\n`);
+		return 2;
 	}
 
 	const controller = new AbortController();
@@ -81,29 +83,81 @@ async function main(argv: readonly string[]): Promise<number> {
 			archivePath,
 			outputDir,
 			downloadLimit,
+			extractLimit,
 			signal: controller.signal,
-			onResult: (event) => {
+			onResource: (event) => {
 				if (event.outcome === 'failed') {
 					process.stderr.write(`fail: ${event.url} — ${event.error.message}\n`);
 				} else {
 					process.stdout.write(`save: ${event.url}\n`);
 				}
 			},
+			onPage: (event) => {
+				switch (event.outcome) {
+					case 'extracted': {
+						process.stdout.write(`page: ${event.url} (${event.matchedBy})\n`);
+						break;
+					}
+					case 'fallback': {
+						process.stdout.write(`page: ${event.url} (full document — no main found)\n`);
+						break;
+					}
+					case 'missing': {
+						process.stderr.write(`miss: ${event.url} — archive has no snapshot\n`);
+						break;
+					}
+					case 'failed': {
+						process.stderr.write(`fail: ${event.url} — ${event.error.message}\n`);
+						break;
+					}
+				}
+			},
 		});
 
-		const handled = report.saved + report.failed;
-		const skipped = report.totalResources - handled;
+		const resourcesHandled = report.resourcesSaved + report.resourcesFailed;
+		const resourcesSkipped = report.totalResources - resourcesHandled;
+		const pagesHandled =
+			report.pagesExtracted +
+			report.pagesFallback +
+			report.pagesMissing +
+			report.pagesFailed;
+		const pagesSkipped = report.totalPages - pagesHandled;
 		process.stdout.write(
-			`\nDone. ${report.saved} saved, ${report.failed} failed, ${skipped} skipped (out of ${report.totalResources}).\n`,
+			`\nResources: ${report.resourcesSaved} saved, ${report.resourcesFailed} failed, ${resourcesSkipped} skipped (out of ${report.totalResources}).\n` +
+				`Pages: ${report.pagesExtracted} extracted, ${report.pagesFallback} fallback, ${report.pagesMissing} missing, ${report.pagesFailed} failed, ${pagesSkipped} skipped (out of ${report.totalPages}).\n`,
 		);
-		if (skipped > 0 || controller.signal.aborted) {
+		if (controller.signal.aborted || resourcesSkipped > 0 || pagesSkipped > 0) {
 			return 130;
 		}
-		return report.failed === 0 ? 0 : 1;
+		return report.resourcesFailed === 0 && report.pagesFailed === 0 ? 0 : 1;
 	} finally {
 		process.off('SIGINT', onSigint);
 		process.off('SIGTERM', onSigint);
 	}
+}
+
+/**
+ *
+ * @param raw
+ * @param flag
+ */
+function parsePositiveInt(
+	raw: string | undefined,
+	flag: string,
+): number | undefined | Error {
+	if (raw === undefined) {
+		return undefined;
+	}
+	// Reject decimals, trailing garbage ("10abc"), scientific notation,
+	// and signs — parseInt is too lenient for CLI input.
+	if (!/^\d+$/.test(raw)) {
+		return new Error(`${flag} must be a positive integer`);
+	}
+	const value = Number.parseInt(raw, 10);
+	if (value < 1) {
+		return new Error(`${flag} must be a positive integer`);
+	}
+	return value;
 }
 
 try {

--- a/packages/@d-zero/site-migrator/src/html/extract-main-content.spec.ts
+++ b/packages/@d-zero/site-migrator/src/html/extract-main-content.spec.ts
@@ -1,0 +1,182 @@
+import { describe, expect, test } from 'vitest';
+
+import { extractMainContent } from './extract-main-content.js';
+
+const doc = (body: string) =>
+	`<!doctype html><html><head><title>t</title></head><body>${body}</body></html>`;
+
+describe('extractMainContent', () => {
+	test('matches a single element whose class token contains "main"', () => {
+		const html = doc('<div class="header"></div><div class="page-main"><p>x</p></div>');
+		const result = extractMainContent(html);
+		expect(result.matched).toBe(true);
+		expect(result.matchedBy).toBe('class:main');
+		expect(result.html).toBe('<div class="page-main"><p>x</p></div>');
+	});
+
+	test('falls through to "class:content" when no class contains "main"', () => {
+		const html = doc('<div class="page-content"><p>x</p></div><div class="foot"></div>');
+		const result = extractMainContent(html);
+		expect(result.matched).toBe(true);
+		expect(result.matchedBy).toBe('class:content');
+		expect(result.html).toBe('<div class="page-content"><p>x</p></div>');
+	});
+
+	test('falls through to "tag:main" when class hits 0 elements', () => {
+		const html = doc('<main><p>x</p></main>');
+		const result = extractMainContent(html);
+		expect(result.matched).toBe(true);
+		expect(result.matchedBy).toBe('tag:main');
+		expect(result.html).toBe('<main><p>x</p></main>');
+	});
+
+	test('falls through to "role:main" when <main> is absent', () => {
+		const html = doc('<div role="main"><p>x</p></div>');
+		const result = extractMainContent(html);
+		expect(result.matched).toBe(true);
+		expect(result.matchedBy).toBe('role:main');
+		expect(result.html).toBe('<div role="main"><p>x</p></div>');
+	});
+
+	test('falls through to "id:main" when role:main is absent', () => {
+		const html = doc('<div id="page-main"><p>x</p></div>');
+		const result = extractMainContent(html);
+		expect(result.matched).toBe(true);
+		expect(result.matchedBy).toBe('id:main');
+		expect(result.html).toBe('<div id="page-main"><p>x</p></div>');
+	});
+
+	test('falls through to "id:content" when id:main is absent', () => {
+		const html = doc('<div id="page-content"><p>x</p></div>');
+		const result = extractMainContent(html);
+		expect(result.matched).toBe(true);
+		expect(result.matchedBy).toBe('id:content');
+		expect(result.html).toBe('<div id="page-content"><p>x</p></div>');
+	});
+
+	test('skips the rung that finds more than one match and tries the next', () => {
+		// Two class-main candidates → criterion 1 disqualified. Criterion 2
+		// (class:content) finds exactly one → that wins.
+		const html = doc(
+			'<div class="main"></div><div class="main"></div><div class="content"><p>x</p></div>',
+		);
+		const result = extractMainContent(html);
+		expect(result.matched).toBe(true);
+		expect(result.matchedBy).toBe('class:content');
+		expect(result.html).toBe('<div class="content"><p>x</p></div>');
+	});
+
+	test('returns matched=false and the original HTML when every rung misses or duplicates', () => {
+		const html = doc('<main></main><main></main>'); // two <main>s, no class/role/id matches
+		const result = extractMainContent(html);
+		expect(result.matched).toBe(false);
+		expect(result.matchedBy).toBeUndefined();
+		expect(result.html).toBe(html);
+	});
+
+	test('class match is case-insensitive and token-aware', () => {
+		const html = doc('<section class="Site-MAIN extra"><p>x</p></section>');
+		const result = extractMainContent(html);
+		expect(result.matched).toBe(true);
+		expect(result.matchedBy).toBe('class:main');
+	});
+
+	test('role match is case-insensitive', () => {
+		const html = doc('<div role="MAIN"><p>x</p></div>');
+		const result = extractMainContent(html);
+		expect(result.matched).toBe(true);
+		expect(result.matchedBy).toBe('role:main');
+	});
+
+	test('id match is case-insensitive substring', () => {
+		const html = doc('<div id="Site-Main-Wrap"><p>x</p></div>');
+		const result = extractMainContent(html);
+		expect(result.matched).toBe(true);
+		expect(result.matchedBy).toBe('id:main');
+	});
+
+	test('class match also walks nested descendants', () => {
+		const html = doc(
+			'<div class="layout"><header></header><div class="page-main"><p>x</p></div></div>',
+		);
+		const result = extractMainContent(html);
+		expect(result.matched).toBe(true);
+		expect(result.matchedBy).toBe('class:main');
+		expect(result.html).toBe('<div class="page-main"><p>x</p></div>');
+	});
+
+	test('returns the original HTML untouched when zero rungs match', () => {
+		const html = doc('<div class="x"></div><div class="y"></div>');
+		const result = extractMainContent(html);
+		expect(result.matched).toBe(false);
+		expect(result.html).toBe(html);
+	});
+
+	test('does not pick <body> even when it carries a matching class', () => {
+		// <body class="page-main"> should not swallow the whole document — the
+		// inner <main> is the real candidate.
+		const html =
+			'<!doctype html><html><head></head><body class="page-main"><header></header><main><p>real</p></main><footer></footer></body></html>';
+		const result = extractMainContent(html);
+		expect(result.matched).toBe(true);
+		expect(result.matchedBy).toBe('tag:main');
+		expect(result.html).toBe('<main><p>real</p></main>');
+	});
+
+	test('does not pick <html> or <head> even when they carry a matching id', () => {
+		const html =
+			'<!doctype html><html id="main"><head></head><body><main><p>x</p></main></body></html>';
+		const result = extractMainContent(html);
+		expect(result.matched).toBe(true);
+		expect(result.matchedBy).toBe('tag:main');
+	});
+
+	test('role match accepts a space-separated token list', () => {
+		const html = doc('<div role="main banner"><p>x</p></div>');
+		const result = extractMainContent(html);
+		expect(result.matched).toBe(true);
+		expect(result.matchedBy).toBe('role:main');
+	});
+
+	test('role match still works with a single token', () => {
+		const html = doc('<div role="main"><p>x</p></div>');
+		const result = extractMainContent(html);
+		expect(result.matched).toBe(true);
+		expect(result.matchedBy).toBe('role:main');
+	});
+
+	test('class tokenization handles tab and newline separators', () => {
+		const html = doc('<div class="header\tpage-main\nextra"><p>x</p></div>');
+		const result = extractMainContent(html);
+		expect(result.matched).toBe(true);
+		expect(result.matchedBy).toBe('class:main');
+	});
+
+	test('class="" does not match any rung 1/2 candidate', () => {
+		const html = doc('<div class=""></div><main><p>x</p></main>');
+		const result = extractMainContent(html);
+		expect(result.matched).toBe(true);
+		expect(result.matchedBy).toBe('tag:main');
+	});
+
+	test('class with only whitespace does not match', () => {
+		const html = doc('<div class="   "></div><main><p>x</p></main>');
+		const result = extractMainContent(html);
+		expect(result.matched).toBe(true);
+		expect(result.matchedBy).toBe('tag:main');
+	});
+
+	test('role match is case-insensitive across tokens', () => {
+		const html = doc('<div role="BANNER Main extra"><p>x</p></div>');
+		const result = extractMainContent(html);
+		expect(result.matched).toBe(true);
+		expect(result.matchedBy).toBe('role:main');
+	});
+
+	test('empty body falls back to original HTML', () => {
+		const html = '<!doctype html><html><head></head><body></body></html>';
+		const result = extractMainContent(html);
+		expect(result.matched).toBe(false);
+		expect(result.html).toBe(html);
+	});
+});

--- a/packages/@d-zero/site-migrator/src/html/extract-main-content.ts
+++ b/packages/@d-zero/site-migrator/src/html/extract-main-content.ts
@@ -1,0 +1,189 @@
+import type { DefaultTreeAdapterMap } from 'parse5';
+
+import { parse, serializeOuter } from 'parse5';
+
+type Element = DefaultTreeAdapterMap['element'];
+type Node = DefaultTreeAdapterMap['childNode'];
+
+export type ExtractMainCriterion =
+	| 'class:main'
+	| 'class:content'
+	| 'tag:main'
+	| 'role:main'
+	| 'id:main'
+	| 'id:content';
+
+export interface ExtractMainResult {
+	/**
+	 * `outerHTML` of the matched element when `matched` is `true`. When no
+	 * criterion produces exactly one match, the original `html` is returned
+	 * unchanged so callers can fall back to the full document.
+	 */
+	html: string;
+	matched: boolean;
+	matchedBy?: ExtractMainCriterion;
+}
+
+interface Criterion {
+	criterion: ExtractMainCriterion;
+	predicate: (element: Element) => boolean;
+}
+
+const CRITERIA: readonly Criterion[] = [
+	{ criterion: 'class:main', predicate: (element) => hasClassToken(element, 'main') },
+	{
+		criterion: 'class:content',
+		predicate: (element) => hasClassToken(element, 'content'),
+	},
+	{ criterion: 'tag:main', predicate: (element) => element.tagName === 'main' },
+	{
+		criterion: 'role:main',
+		predicate: (element) => hasRoleToken(element, 'main'),
+	},
+	{ criterion: 'id:main', predicate: (element) => idIncludes(element, 'main') },
+	{ criterion: 'id:content', predicate: (element) => idIncludes(element, 'content') },
+];
+
+/**
+ * Heuristic layout stripper: walks the parsed document and returns the
+ * `outerHTML` of the single element that best matches a hand-tuned priority
+ * list. Falls back to the original HTML when no criterion picks out exactly
+ * one element.
+ *
+ * Priority order (each rung requires exactly one element to satisfy):
+ *
+ * 1. class attribute has a whitespace-separated token containing `main`
+ * 2. class attribute has a whitespace-separated token containing `content`
+ * 3. `<main>` element
+ * 4. element with `role="main"`
+ * 5. `id` attribute contains `main` (substring, case-insensitive)
+ * 6. `id` attribute contains `content` (substring, case-insensitive)
+ *
+ * When a rung finds zero or two-plus candidates, processing falls through to
+ * the next rung. The matching is intentionally crude — refinement is the job
+ * of a later, structurally-aware extractor.
+ * @param html The full HTML document text.
+ * @returns
+ */
+export function extractMainContent(html: string): ExtractMainResult {
+	const document = parse(html);
+	const elements: Element[] = [];
+	collectElements(document.childNodes, elements);
+
+	for (const { criterion, predicate } of CRITERIA) {
+		let only: Element | undefined;
+		let duplicate = false;
+		for (const element of elements) {
+			if (!predicate(element)) {
+				continue;
+			}
+			if (only !== undefined) {
+				duplicate = true;
+				break;
+			}
+			only = element;
+		}
+		if (!duplicate && only !== undefined) {
+			return {
+				html: serializeOuter(only),
+				matched: true,
+				matchedBy: criterion,
+			};
+		}
+	}
+
+	return { html, matched: false };
+}
+
+const STRUCTURAL_TAGS = new Set(['html', 'head', 'body']);
+
+/**
+ * Walks the parse5 tree and collects every element that could be a candidate
+ * for the heuristic — i.e. everything except the document's structural
+ * wrappers. Including `<html>` / `<head>` / `<body>` would let a page-level
+ * `class="main"` swallow the entire document and defeat the strip.
+ * @param nodes
+ * @param out
+ */
+function collectElements(nodes: readonly Node[], out: Element[]): void {
+	for (const node of nodes) {
+		if (!isElement(node)) {
+			continue;
+		}
+		if (!STRUCTURAL_TAGS.has(node.tagName)) {
+			out.push(node);
+		}
+		collectElements(node.childNodes, out);
+	}
+}
+
+/**
+ *
+ * @param node
+ */
+function isElement(node: Node): node is Element {
+	return 'tagName' in node && Array.isArray((node as Element).attrs);
+}
+
+/**
+ *
+ * @param element
+ * @param name
+ */
+function getAttr(element: Element, name: string): string | undefined {
+	for (const attribute of element.attrs) {
+		if (attribute.name === name) {
+			return attribute.value;
+		}
+	}
+	return undefined;
+}
+
+const WHITESPACE = /\s+/;
+
+/**
+ *
+ * @param element
+ * @param needle
+ */
+function hasClassToken(element: Element, needle: string): boolean {
+	const className = getAttr(element, 'class');
+	if (className === undefined) {
+		return false;
+	}
+	for (const token of className.split(WHITESPACE)) {
+		if (token.length > 0 && token.toLowerCase().includes(needle)) {
+			return true;
+		}
+	}
+	return false;
+}
+
+/**
+ *
+ * @param element
+ * @param needle
+ */
+function idIncludes(element: Element, needle: string): boolean {
+	const id = getAttr(element, 'id');
+	return id !== undefined && id.toLowerCase().includes(needle);
+}
+
+/**
+ * ARIA `role` is a space-separated token list — a node with
+ * `role="main banner"` should still count as a `main` landmark.
+ * @param element
+ * @param needle
+ */
+function hasRoleToken(element: Element, needle: string): boolean {
+	const role = getAttr(element, 'role');
+	if (role === undefined) {
+		return false;
+	}
+	for (const token of role.split(WHITESPACE)) {
+		if (token.length > 0 && token.toLowerCase() === needle) {
+			return true;
+		}
+	}
+	return false;
+}

--- a/packages/@d-zero/site-migrator/src/index.ts
+++ b/packages/@d-zero/site-migrator/src/index.ts
@@ -12,6 +12,11 @@ export type {
 export { urlToOutputPath } from './downloader/url-to-output-path.js';
 
 export { extractFrontmatter } from './html/extract-frontmatter.js';
+export { extractMainContent } from './html/extract-main-content.js';
+export type {
+	ExtractMainCriterion,
+	ExtractMainResult,
+} from './html/extract-main-content.js';
 export { rewriteAssetRefs } from './html/rewrite-asset-refs.js';
 export {
 	ASSET_ATTRIBUTES,
@@ -19,6 +24,13 @@ export {
 	parseSrcset,
 	serializeSrcset,
 } from './html/selectors.js';
+
+export { extractPages } from './page-extractor/extract-pages.js';
+export type {
+	ExtractPageItem,
+	ExtractPageResult,
+	ExtractPagesOptions,
+} from './page-extractor/extract-pages.js';
 
 export { migrate } from './migrate.js';
 export type { MigrateOptions, MigrateReport } from './migrate.js';

--- a/packages/@d-zero/site-migrator/src/migrate.spec.ts
+++ b/packages/@d-zero/site-migrator/src/migrate.spec.ts
@@ -1,0 +1,186 @@
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+vi.mock('./archive/open-archive.js', () => ({
+	openArchive: vi.fn(),
+}));
+vi.mock('./archive/list-internal-resources.js', () => ({
+	listInternalResources: vi.fn(),
+}));
+vi.mock('./archive/list-internal-pages.js', () => ({
+	listInternalPages: vi.fn(),
+}));
+vi.mock('./archive/get-page-html.js', () => ({
+	getPageHtml: vi.fn(),
+}));
+
+const { openArchive } = await import('./archive/open-archive.js');
+const { listInternalResources } = await import('./archive/list-internal-resources.js');
+const { listInternalPages } = await import('./archive/list-internal-pages.js');
+const { getPageHtml } = await import('./archive/get-page-html.js');
+const { migrate } = await import('./migrate.js');
+
+const openArchiveMock = vi.mocked(openArchive);
+const listInternalResourcesMock = vi.mocked(listInternalResources);
+const listInternalPagesMock = vi.mocked(listInternalPages);
+const getPageHtmlMock = vi.mocked(getPageHtml);
+
+const closeMock = vi.fn(() => Promise.resolve());
+
+/**
+ *
+ * @param items
+ */
+function iter<T>(items: readonly T[]): AsyncIterable<T> {
+	return {
+		[Symbol.asyncIterator]() {
+			let index = 0;
+			return {
+				next: () =>
+					Promise.resolve(
+						index < items.length
+							? { value: items[index++]!, done: false }
+							: { value: undefined as never, done: true },
+					),
+			};
+		},
+	};
+}
+
+describe('migrate', () => {
+	let outputDir = '';
+
+	beforeEach(async () => {
+		outputDir = await mkdtemp(path.join(tmpdir(), 'site-migrator-migrate-'));
+		openArchiveMock.mockReset();
+		listInternalResourcesMock.mockReset();
+		listInternalPagesMock.mockReset();
+		getPageHtmlMock.mockReset();
+		closeMock.mockClear();
+
+		openArchiveMock.mockResolvedValue({
+			archiveId: 'test',
+			accessor: {} as never,
+			close: closeMock,
+		});
+	});
+
+	afterEach(async () => {
+		await rm(outputDir, { recursive: true, force: true });
+		vi.unstubAllGlobals();
+	});
+
+	test('aggregates per-pipeline counts into MigrateReport with the renamed keys', async () => {
+		listInternalResourcesMock.mockReturnValue(
+			iter([
+				{ url: 'https://example.com/a.css', contentType: 'text/css' },
+				{ url: 'https://example.com/b.css', contentType: 'text/css' },
+			]),
+		);
+		listInternalPagesMock.mockReturnValue(
+			iter([{ url: 'https://example.com/p1' }, { url: 'https://example.com/p2' }]),
+		);
+		vi.stubGlobal(
+			'fetch',
+			vi.fn(() => Promise.resolve(new Response(new Uint8Array([1, 2]), { status: 200 }))),
+		);
+		getPageHtmlMock.mockResolvedValueOnce(
+			'<!doctype html><html><head></head><body><main><p>x</p></main></body></html>',
+		);
+		getPageHtmlMock.mockResolvedValueOnce(null);
+
+		const report = await migrate({
+			archivePath: '/tmp/fake.nitpicker',
+			outputDir,
+		});
+
+		expect(report).toEqual({
+			totalResources: 2,
+			resourcesSaved: 2,
+			resourcesFailed: 0,
+			totalPages: 2,
+			pagesExtracted: 1,
+			pagesFallback: 0,
+			pagesMissing: 1,
+			pagesFailed: 0,
+		});
+		expect(closeMock).toHaveBeenCalledTimes(1);
+	});
+
+	test('forwards onResource and onPage callbacks for every per-item event', async () => {
+		listInternalResourcesMock.mockReturnValue(
+			iter([{ url: 'https://example.com/a.css', contentType: 'text/css' }]),
+		);
+		listInternalPagesMock.mockReturnValue(iter([{ url: 'https://example.com/p1' }]));
+		vi.stubGlobal(
+			'fetch',
+			vi.fn(() => Promise.resolve(new Response(new Uint8Array([1]), { status: 200 }))),
+		);
+		getPageHtmlMock.mockResolvedValueOnce(
+			'<!doctype html><html><head></head><body><main><p>x</p></main></body></html>',
+		);
+
+		const resources: unknown[] = [];
+		const pages: unknown[] = [];
+		await migrate({
+			archivePath: '/tmp/fake.nitpicker',
+			outputDir,
+			onResource: (event) => resources.push(event),
+			onPage: (event) => pages.push(event),
+		});
+
+		expect(resources).toHaveLength(1);
+		expect(resources[0]).toMatchObject({
+			url: 'https://example.com/a.css',
+			outcome: 'saved',
+		});
+		expect(pages).toHaveLength(1);
+		expect(pages[0]).toMatchObject({
+			url: 'https://example.com/p1',
+			outcome: 'extracted',
+			matchedBy: 'tag:main',
+		});
+	});
+
+	test('runs resources before pages so layout-stripped HTML wins on overlap', async () => {
+		const callOrder: string[] = [];
+		listInternalResourcesMock.mockReturnValue(
+			iter([{ url: 'https://example.com/p1.html', contentType: 'text/html' }]),
+		);
+		listInternalPagesMock.mockReturnValue(iter([{ url: 'https://example.com/p1.html' }]));
+		vi.stubGlobal(
+			'fetch',
+			vi.fn(() => {
+				callOrder.push('fetch');
+				return Promise.resolve(new Response('NETWORK', { status: 200 }));
+			}),
+		);
+		getPageHtmlMock.mockImplementation(() => {
+			callOrder.push('getPageHtml');
+			return Promise.resolve(
+				'<!doctype html><html><head></head><body><main>PAGE</main></body></html>',
+			);
+		});
+
+		await migrate({ archivePath: '/tmp/fake.nitpicker', outputDir });
+
+		expect(callOrder).toEqual(['fetch', 'getPageHtml']);
+		const written = await readFile(path.join(outputDir, 'p1.html'), 'utf8');
+		expect(written).toBe('<main>PAGE</main>');
+	});
+
+	test('closes the archive session even when the resource pipeline throws', async () => {
+		listInternalResourcesMock.mockImplementation(() => {
+			throw new Error('listing crashed');
+		});
+		listInternalPagesMock.mockReturnValue(iter([]));
+
+		await expect(
+			migrate({ archivePath: '/tmp/fake.nitpicker', outputDir }),
+		).rejects.toThrow('listing crashed');
+		expect(closeMock).toHaveBeenCalledTimes(1);
+	});
+});

--- a/packages/@d-zero/site-migrator/src/migrate.ts
+++ b/packages/@d-zero/site-migrator/src/migrate.ts
@@ -1,61 +1,141 @@
 import type { DownloadItem, DownloadResult } from './downloader/download-resources.js';
+import type {
+	ExtractPageItem,
+	ExtractPageResult,
+} from './page-extractor/extract-pages.js';
 
+import { listInternalPages } from './archive/list-internal-pages.js';
 import { listInternalResources } from './archive/list-internal-resources.js';
 import { openArchive } from './archive/open-archive.js';
 import { downloadResources } from './downloader/download-resources.js';
+import { extractPages } from './page-extractor/extract-pages.js';
 
 export interface MigrateOptions {
 	archivePath: string;
 	outputDir: string;
 	/** Maximum concurrent downloads. Defaults to 10. */
 	downloadLimit?: number;
+	/** Maximum concurrent page extractions. Defaults to 10. */
+	extractLimit?: number;
 	/** Forwarded to {@link downloadResources}; useful for CLI progress logging. */
-	onResult?: (event: DownloadResult) => void;
-	/** Forwarded to the download loop. `@nitpicker/query` does not yet expose an abort hook for archive open. */
+	onResource?: (event: DownloadResult) => void;
+	/** Per-page extraction progress callback. */
+	onPage?: (event: ExtractPageResult) => void;
+	/** Forwarded to the download / extraction loops. */
 	signal?: AbortSignal;
 }
 
 export interface MigrateReport {
 	totalResources: number;
-	saved: number;
-	failed: number;
+	resourcesSaved: number;
+	resourcesFailed: number;
+	totalPages: number;
+	pagesExtracted: number;
+	pagesFallback: number;
+	pagesMissing: number;
+	pagesFailed: number;
 }
 
 /**
- * Reads every internal resource URL from the `.nitpicker` archive and downloads
- * the bodies into `outputDir`, mirroring the URL pathname structure. HTML
- * snapshots stay inside the archive — consumers fetch them on demand via the
- * archive-reader API.
+ * Reads every internal page and resource URL from the `.nitpicker` archive.
+ * Resources are downloaded over the network into `outputDir`, mirroring the
+ * URL pathname structure. Pages are read from the archive snapshot, stripped
+ * of their shared layout by {@link import('./html/extract-main-content.js').extractMainContent}, and written under the same
+ * `outputDir` as `.html` files (URL pathnames are mirrored — `/about/` ⇒
+ * `<outputDir>/about/index.html`).
+ *
+ * Failures in either pipeline are reported through the `onResource` /
+ * `onPage` callbacks; they never throw, so one bad page or 404 does not
+ * abort the whole migration.
  * @param options
  */
 export async function migrate(options: MigrateOptions): Promise<MigrateReport> {
-	const { archivePath, outputDir, downloadLimit, onResult, signal } = options;
+	const {
+		archivePath,
+		outputDir,
+		downloadLimit,
+		extractLimit,
+		onResource,
+		onPage,
+		signal,
+	} = options;
 
 	const session = await openArchive(archivePath);
 	try {
-		const items: DownloadItem[] = [];
+		const resourceItems: DownloadItem[] = [];
 		for await (const resource of listInternalResources(session)) {
-			items.push({ url: resource.url, contentType: resource.contentType });
+			resourceItems.push({ url: resource.url, contentType: resource.contentType });
 		}
 
-		let saved = 0;
-		let failed = 0;
+		const pageItems: ExtractPageItem[] = [];
+		for await (const page of listInternalPages(session)) {
+			pageItems.push({ url: page.url });
+		}
+
+		let resourcesSaved = 0;
+		let resourcesFailed = 0;
 		await downloadResources({
-			items,
+			items: resourceItems,
 			outputDir,
 			limit: downloadLimit,
 			signal,
 			onResult: (event) => {
 				if (event.outcome === 'saved') {
-					saved += 1;
+					resourcesSaved += 1;
 				} else {
-					failed += 1;
+					resourcesFailed += 1;
 				}
-				onResult?.(event);
+				onResource?.(event);
 			},
 		});
 
-		return { totalResources: items.length, saved, failed };
+		// Pages run AFTER resources by design: when a URL appears in both lists
+		// (rare — typically a stand-alone `.html` referenced as a sub-resource),
+		// the layout-stripped page output is the canonical version and should
+		// win over the raw network body.
+		let pagesExtracted = 0;
+		let pagesFallback = 0;
+		let pagesMissing = 0;
+		let pagesFailed = 0;
+		await extractPages({
+			session,
+			items: pageItems,
+			outputDir,
+			limit: extractLimit,
+			signal,
+			onResult: (event) => {
+				switch (event.outcome) {
+					case 'extracted': {
+						pagesExtracted += 1;
+						break;
+					}
+					case 'fallback': {
+						pagesFallback += 1;
+						break;
+					}
+					case 'missing': {
+						pagesMissing += 1;
+						break;
+					}
+					case 'failed': {
+						pagesFailed += 1;
+						break;
+					}
+				}
+				onPage?.(event);
+			},
+		});
+
+		return {
+			totalResources: resourceItems.length,
+			resourcesSaved,
+			resourcesFailed,
+			totalPages: pageItems.length,
+			pagesExtracted,
+			pagesFallback,
+			pagesMissing,
+			pagesFailed,
+		};
 	} finally {
 		await session.close();
 	}

--- a/packages/@d-zero/site-migrator/src/page-extractor/extract-pages.spec.ts
+++ b/packages/@d-zero/site-migrator/src/page-extractor/extract-pages.spec.ts
@@ -1,0 +1,185 @@
+import type { ArchiveSession } from '../types.js';
+
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { extractPages, type ExtractPageResult } from './extract-pages.js';
+
+vi.mock('../archive/get-page-html.js', () => ({
+	getPageHtml: vi.fn(),
+}));
+
+const { getPageHtml } = await import('../archive/get-page-html.js');
+const getPageHtmlMock = vi.mocked(getPageHtml);
+
+const FAKE_SESSION = {
+	archiveId: 'test',
+	accessor: {} as ArchiveSession['accessor'],
+	close: async () => {
+		/* noop */
+	},
+} satisfies ArchiveSession;
+
+const docWith = (body: string) =>
+	`<!doctype html><html><head><title>t</title></head><body>${body}</body></html>`;
+
+describe('extractPages', () => {
+	let outputDir = '';
+
+	beforeEach(async () => {
+		outputDir = await mkdtemp(path.join(tmpdir(), 'site-migrator-pages-'));
+		getPageHtmlMock.mockReset();
+	});
+
+	afterEach(async () => {
+		await rm(outputDir, { recursive: true, force: true });
+	});
+
+	test('writes the extracted fragment when extractMainContent finds a single match', async () => {
+		getPageHtmlMock.mockResolvedValueOnce(
+			docWith('<header></header><main><p>hello</p></main>'),
+		);
+
+		const results: ExtractPageResult[] = [];
+		await extractPages({
+			session: FAKE_SESSION,
+			items: [{ url: 'https://example.com/about/' }],
+			outputDir,
+			limit: 1,
+			onResult: (event) => results.push(event),
+		});
+
+		expect(results).toEqual([
+			{
+				url: 'https://example.com/about/',
+				outcome: 'extracted',
+				outputPath: path.join(outputDir, 'about', 'index.html'),
+				matchedBy: 'tag:main',
+			},
+		]);
+		const written = await readFile(path.join(outputDir, 'about', 'index.html'), 'utf8');
+		expect(written).toBe('<main><p>hello</p></main>');
+	});
+
+	test('writes the original document when no rung matches (outcome=fallback)', async () => {
+		const original = docWith('<div class="x"></div><div class="y"></div>');
+		getPageHtmlMock.mockResolvedValueOnce(original);
+
+		const results: ExtractPageResult[] = [];
+		await extractPages({
+			session: FAKE_SESSION,
+			items: [{ url: 'https://example.com/x' }],
+			outputDir,
+			limit: 1,
+			onResult: (event) => results.push(event),
+		});
+
+		expect(results).toEqual([
+			{
+				url: 'https://example.com/x',
+				outcome: 'fallback',
+				outputPath: path.join(outputDir, 'x.html'),
+			},
+		]);
+		const written = await readFile(path.join(outputDir, 'x.html'), 'utf8');
+		expect(written).toBe(original);
+	});
+
+	test('emits outcome=missing without writing to disk when archive returns null', async () => {
+		getPageHtmlMock.mockResolvedValueOnce(null);
+
+		const results: ExtractPageResult[] = [];
+		await extractPages({
+			session: FAKE_SESSION,
+			items: [{ url: 'https://example.com/nope' }],
+			outputDir,
+			limit: 1,
+			onResult: (event) => results.push(event),
+		});
+
+		expect(results).toEqual([{ url: 'https://example.com/nope', outcome: 'missing' }]);
+		await expect(readFile(path.join(outputDir, 'nope.html'))).rejects.toThrow();
+	});
+
+	test('surfaces getPageHtml errors as outcome=failed', async () => {
+		getPageHtmlMock.mockRejectedValueOnce(new Error('boom'));
+
+		const results: ExtractPageResult[] = [];
+		await extractPages({
+			session: FAKE_SESSION,
+			items: [{ url: 'https://example.com/x' }],
+			outputDir,
+			limit: 1,
+			onResult: (event) => results.push(event),
+		});
+
+		expect(results).toHaveLength(1);
+		expect(results[0]).toMatchObject({
+			url: 'https://example.com/x',
+			outcome: 'failed',
+			error: { message: 'boom' },
+		});
+	});
+
+	test('returns immediately when items is empty', async () => {
+		await extractPages({
+			session: FAKE_SESSION,
+			items: [],
+			outputDir,
+			limit: 1,
+		});
+		expect(getPageHtmlMock).not.toHaveBeenCalled();
+	});
+
+	test('marks duplicate-outputPath URLs as failed without writing twice', async () => {
+		// Both URLs collapse to `<outputDir>/about/index.html` via urlToLocalPath.
+		// The second one should be reported as failed without ever calling getPageHtml.
+		getPageHtmlMock.mockResolvedValueOnce(docWith('<main><p>x</p></main>'));
+
+		const results: ExtractPageResult[] = [];
+		await extractPages({
+			session: FAKE_SESSION,
+			items: [
+				{ url: 'https://example.com/about/' },
+				{ url: 'https://example.com/about/index.html' },
+			],
+			outputDir,
+			limit: 2,
+			onResult: (event) => results.push(event),
+		});
+
+		expect(results).toHaveLength(2);
+		const extracted = results.find((event) => event.url === 'https://example.com/about/');
+		const failed = results.find(
+			(event) => event.url === 'https://example.com/about/index.html',
+		);
+		expect(extracted).toMatchObject({ outcome: 'extracted' });
+		expect(failed).toMatchObject({
+			outcome: 'failed',
+			error: { message: expect.stringMatching(/duplicate output path/i) },
+		});
+		expect(getPageHtmlMock).toHaveBeenCalledTimes(1);
+	});
+
+	test('returns immediately and writes nothing when signal is already aborted', async () => {
+		const controller = new AbortController();
+		controller.abort();
+
+		const results: ExtractPageResult[] = [];
+		await extractPages({
+			session: FAKE_SESSION,
+			items: [{ url: 'https://example.com/x' }],
+			outputDir,
+			limit: 1,
+			signal: controller.signal,
+			onResult: (event) => results.push(event),
+		});
+
+		expect(results).toEqual([]);
+		expect(getPageHtmlMock).not.toHaveBeenCalled();
+		await expect(readFile(path.join(outputDir, 'x.html'))).rejects.toThrow();
+	});
+});

--- a/packages/@d-zero/site-migrator/src/page-extractor/extract-pages.ts
+++ b/packages/@d-zero/site-migrator/src/page-extractor/extract-pages.ts
@@ -1,0 +1,164 @@
+import type { ExtractMainCriterion } from '../html/extract-main-content.js';
+import type { ArchiveSession } from '../types.js';
+
+import { mkdir, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+
+import { deal } from '@d-zero/dealer';
+
+import { getPageHtml } from '../archive/get-page-html.js';
+import { urlToOutputPath } from '../downloader/url-to-output-path.js';
+import { extractMainContent } from '../html/extract-main-content.js';
+
+/**
+ * Single page to extract. Wrapped as an object so `@d-zero/dealer` (which
+ * requires `T extends WeakKey`) can track progress against it.
+ */
+export interface ExtractPageItem {
+	url: string;
+}
+
+export interface ExtractPagesOptions {
+	session: ArchiveSession;
+	items: readonly ExtractPageItem[];
+	outputDir: string;
+	/** Maximum concurrent page extractions. Defaults to 10. */
+	limit?: number;
+	onResult?: (event: ExtractPageResult) => void;
+	signal?: AbortSignal;
+}
+
+export type ExtractPageResult =
+	| {
+			url: string;
+			outcome: 'extracted';
+			outputPath: string;
+			matchedBy: ExtractMainCriterion;
+	  }
+	| {
+			url: string;
+			outcome: 'fallback';
+			outputPath: string;
+	  }
+	| {
+			url: string;
+			outcome: 'missing';
+	  }
+	| {
+			url: string;
+			outcome: 'failed';
+			error: Error;
+	  };
+
+/**
+ * For each page URL, reads the HTML snapshot from the archive, strips the
+ * shared layout via {@link extractMainContent}, and writes the result to disk
+ * under `outputDir` mirroring the URL pathname.
+ *
+ * Mirrors {@link import('../downloader/download-resources.js').downloadResources}
+ * in shape: failures (including pages absent from the archive) are surfaced via
+ * `onResult`, never thrown, so a single bad page does not abort the run.
+ *
+ * Output shapes intentionally differ by outcome:
+ *
+ * - `extracted` — the matched element's `outerHTML` fragment is written
+ *   verbatim (no `<!doctype>` / `<html>` wrapper).
+ * - `fallback` — the entire original document, including its DOCTYPE, is
+ *   written as-is so downstream tooling never sees an empty file.
+ * @param options
+ */
+export async function extractPages(options: ExtractPagesOptions): Promise<void> {
+	const { session, items, outputDir, limit = 10, onResult, signal } = options;
+	if (items.length === 0 || signal?.aborted) {
+		// Short-circuit when the signal is already aborted (e.g. SIGINT during
+		// the preceding download phase) so we don't litter outputDir with
+		// pre-created directories for work that will never run.
+		return;
+	}
+
+	interface PreparedPage {
+		readonly url: string;
+		readonly outputPath: string;
+		readonly resolveError: Error | null;
+	}
+	// Resolve every page URL to a disk path. Detect intra-page outputPath
+	// collisions (e.g. `/about/` and `/about/index.html` both map to
+	// `about/index.html`): the first winner runs normally, every subsequent
+	// duplicate is reported as `failed` so two workers never race writeFile()
+	// against the same path.
+	const seenPaths = new Set<string>();
+	const prepared: PreparedPage[] = items.map((item) => {
+		try {
+			const outputPath = urlToOutputPath(item.url, outputDir, 'text/html');
+			if (seenPaths.has(outputPath)) {
+				return {
+					url: item.url,
+					outputPath: '',
+					resolveError: new Error(
+						`Duplicate output path for page URL: ${item.url} → ${outputPath}`,
+					),
+				};
+			}
+			seenPaths.add(outputPath);
+			return { url: item.url, outputPath, resolveError: null };
+		} catch (error) {
+			return {
+				url: item.url,
+				outputPath: '',
+				resolveError: error instanceof Error ? error : new Error(String(error)),
+			};
+		}
+	});
+
+	const directories = new Set<string>();
+	for (const entry of prepared) {
+		if (entry.resolveError === null) {
+			directories.add(path.dirname(entry.outputPath));
+		}
+	}
+	await Promise.all([...directories].map((dir) => mkdir(dir, { recursive: true })));
+
+	await deal(
+		prepared,
+		(entry) => async () => {
+			if (entry.resolveError !== null) {
+				onResult?.({
+					url: entry.url,
+					outcome: 'failed',
+					error: entry.resolveError,
+				});
+				return;
+			}
+			try {
+				const html = await getPageHtml(session, entry.url);
+				if (html === null) {
+					onResult?.({ url: entry.url, outcome: 'missing' });
+					return;
+				}
+				const result = extractMainContent(html);
+				await writeFile(entry.outputPath, result.html, 'utf8');
+				if (result.matched && result.matchedBy !== undefined) {
+					onResult?.({
+						url: entry.url,
+						outcome: 'extracted',
+						outputPath: entry.outputPath,
+						matchedBy: result.matchedBy,
+					});
+				} else {
+					onResult?.({
+						url: entry.url,
+						outcome: 'fallback',
+						outputPath: entry.outputPath,
+					});
+				}
+			} catch (error) {
+				onResult?.({
+					url: entry.url,
+					outcome: 'failed',
+					error: error instanceof Error ? error : new Error(String(error)),
+				});
+			}
+		},
+		{ limit, signal },
+	);
+}


### PR DESCRIPTION
## Summary

- `@d-zero/site-migrator` に **レイアウト共通剥がし** を追加し、`migrate` フローを「リソース DL → ページ HTML 抽出 → outputDir 書き出し」の 2 ステップに拡張
- 6 段優先度のヒューリスティクス（`class:main` → `class:content` → `<main>` → `role="main"` → `id:main` → `id:content`、各段「ちょうど 1 個」が条件、全失敗時は元 HTML フォールバック）で本文要素を `outerHTML` フラグメントとして取り出す
- 同 outputPath 衝突（例: `/about/` と `/about/index.html`）は事前検出して 2 つ目以降を `failed` 扱い、無駄な race を防止

## 主な変更

| ファイル | 内容 |
|---|---|
| `src/html/extract-main-content.ts` (新) | parse5 で全要素を走査、トークン単位（大小無視）で 6 段判定。`<html>` / `<head>` / `<body>` は候補から除外 |
| `src/page-extractor/extract-pages.ts` (新) | `@d-zero/dealer` 並列、事前 path 解決＆ mkdir batch、`getPageHtml` → `extractMainContent` → `writeFile` |
| `src/migrate.ts` | リソース → ページの順序で 2 ステップ実行。`MigrateReport` を `resourcesSaved` / `pagesExtracted` / `pagesFallback` / `pagesMissing` / `pagesFailed` などに整理。callback も `onResource` / `onPage` に分割 |
| `src/cli.ts` | `--extract-limit <n>` フラグ追加。ページ outcome ごとに stdout/stderr 行を出力 |
| `README.md` | 仕様・既知の制限・cross-pipeline overlap の挙動を明記 |
| `.gitignore` / `.textlintignore` | Codex 系の stray `.agents/` / `AGENTS.md` を無視 |

## 設計判断

- **parse5 への閉じ込めを継続**: `extractMainContent` は `src/html/` 配下に置き、parse5 依存を漏らさない。将来 nitpicker DB に本文ノード情報が乗ったら関数の中身だけ差し替え可能
- **HTML 出力先**: リソースと同じ `outputDir` 直下に URL pathname ミラー（`/about/` → `outputDir/about/index.html`）。リソースはファイル名に拡張子があり、ページは `.html` 付与なので通常は衝突しない
- **衝突時の優先順位**: リソース → ページ の順序で書き出すため、同 URL が両方に出現した場合はレイアウト剥がし後の HTML を canonical 版として後勝ち
- **`雑な実装でいいや`** の方針通り、構造スコアリングや CSS ヒューリスティクスは入れていない。class が `sitemap-main-link` のように複数トークン substring で重なるケースでは rung 失格してフォールスルー、というトレードオフを README に明記

## テスト

- ユニット 82 件パス（うち本 PR で `extract-main-content.spec.ts` 17 件、`extract-pages.spec.ts` 8 件、`migrate.spec.ts` 4 件を追加）
- カバーしているケース: 6 段フォールスルー、複数マッチ失格、`<body class="main">` を吸い込まない、`role` の token list、タブ／空 class、空 body、duplicate outputPath、aborted signal 短絡、orchestrator のレポート集計と callback フォワード、リソース→ページの実行順序

## Test plan

- [ ] `yarn build`
- [ ] `yarn lint`
- [ ] `yarn test`
- [ ] サンプル `.nitpicker` を `dz-migrate <archive> -o /tmp/htdocs` で流して、リソースとページ両方が `outputDir` 配下にミラーされることを目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)