### PR TITLE
feat(site-migrator): rewrite same-origin URL refs and assign per-page integer ids

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -17,6 +17,7 @@
 		"absolutised",
 		"srcsets",
 		"unstub",
+		"vbscript",
 		"whatwg"
 	]
 }

--- a/packages/@d-zero/site-migrator/README.md
+++ b/packages/@d-zero/site-migrator/README.md
@@ -1,6 +1,6 @@
 # `@d-zero/site-migrator`
 
-`.nitpicker` アーカイブを入力とするウェブサイト移植ツールキット。サブリソースのローカル DL、ページ HTML のレイアウト剥がし、`.nitpicker` DB のページメタを YAML frontmatter として prepend する CLI、および後続の変換処理で使うユーティリティ関数群を提供する。
+`.nitpicker` アーカイブを入力とするウェブサイト移植ツールキット。サブリソースのローカル DL、ページ HTML のレイアウト剥がし、`.nitpicker` DB のページメタと採番した整数 id を YAML frontmatter として prepend する CLI、同一オリジン参照を後段パイプライン向けに書き換えるリライタ、および周辺ユーティリティ関数群を提供する。
 
 ## Installation
 
@@ -19,7 +19,7 @@ npx dz-migrate <archive.nitpicker> -o <htdocs-dir> [--limit <n>] [--extract-limi
 - `--limit <n>` — 並列 DL 数（デフォルト 10）
 - `--extract-limit <n>` — 並列ページ抽出数（デフォルト 10）
 
-リソースは fetch で DL、ページ HTML はアーカイブ内のスナップショットを読み、`extractMainContent` でレイアウト共通部分を剥がし、`.nitpicker` DB のページメタを `getFrontmatter` で読み出して `formatFrontmatter` が生成する `---\n…\n---\n` YAML ブロックを先頭に prepend してから `.html` として書き出す。
+リソースは fetch で DL、ページ HTML はアーカイブ内のスナップショットを読み、`extractMainContent` でレイアウト共通部分を剥がし、`assignPageIds` で URL → 整数 id の写像を組み立てて `.nitpicker` DB のページメタと併せて `formatFrontmatter` が生成する `---\n…\n---\n` YAML ブロックを先頭に prepend、本文中の同一オリジン参照を `rewritePageRefs` が書き換えてから `.html` として書き出す。
 
 ## Programmatic API
 
@@ -38,26 +38,32 @@ import {
 	extractPages,
 	formatFrontmatter,
 	splitTitle,
+	assignPageIds,
+	buildPageIdLookup,
+	rewritePageRefs,
 } from '@d-zero/site-migrator';
 ```
 
 主要 API:
 
-| 関数                    | 概要                                                                             |
-| ----------------------- | -------------------------------------------------------------------------------- | ------------------------------------------ |
-| `migrate`               | アーカイブを開き、リソース DL とページ抽出を並列実行する全体フロー               |
-| `openArchive`           | `.nitpicker` を開いてセッションを返す（要 `close()`）                            |
-| `listInternalPages`     | 内部ページ URL を順に yield する非同期イテラブル                                 |
-| `listInternalResources` | 内部リソース URL を順に yield する非同期イテラブル                               |
-| `getPageHtml`           | レンダリング後 HTML を全長で取得（truncate なし）                                |
-| `getFrontmatter`        | `.nitpicker` DB の flat meta カラムを `Frontmatter` へマップ                     |
-| `downloadResources`     | URL リストを並列 fetch してローカルへ保存                                        |
-| `urlToOutputPath`       | URL を `<htdocs-dir>` 配下のローカルパスへ変換                                   |
-| `rewriteAssetRefs`      | HTML 内のアセット参照を resolver で書き換える（streaming）                       |
-| `extractMainContent`    | レイアウト共通部分を剥がして本文要素の `outerHTML` を返す                        |
-| `extractPages`          | ページ一覧に `extractMainContent` + `getFrontmatter` を適用して書き出す          |
-| `formatFrontmatter`     | `Frontmatter` を後段パイプライン互換の `---\n…\n---\n` YAML ブロック文字列にする |
-| `splitTitle`            | タイトル文字列を `｜` / `                                                        | `で分割し`{title, rawTitle?}` を返す純関数 |
+| 関数                    | 概要                                                                                      |
+| ----------------------- | ----------------------------------------------------------------------------------------- | ------------------------------------------ |
+| `migrate`               | アーカイブを開き、リソース DL とページ抽出を並列実行する全体フロー                        |
+| `openArchive`           | `.nitpicker` を開いてセッションを返す（要 `close()`）                                     |
+| `listInternalPages`     | 内部ページ URL を順に yield する非同期イテラブル                                          |
+| `listInternalResources` | 内部リソース URL を順に yield する非同期イテラブル                                        |
+| `getPageHtml`           | レンダリング後 HTML を全長で取得（truncate なし）                                         |
+| `getFrontmatter`        | `.nitpicker` DB の flat meta カラムを `Frontmatter` へマップ                              |
+| `downloadResources`     | URL リストを並列 fetch してローカルへ保存                                                 |
+| `urlToOutputPath`       | URL を `<htdocs-dir>` 配下のローカルパスへ変換                                            |
+| `rewriteAssetRefs`      | HTML 内のアセット参照を resolver で書き換える（streaming）                                |
+| `extractMainContent`    | レイアウト共通部分を剥がして本文要素の `outerHTML` を返す                                 |
+| `extractPages`          | ページ一覧に `extractMainContent` + `getFrontmatter` を適用して書き出す                   |
+| `formatFrontmatter`     | `Frontmatter` を後段パイプライン互換の `---\n…\n---\n` YAML ブロック文字列にする          |
+| `splitTitle`            | タイトル文字列を `｜` / `                                                                 | `で分割し`{title, rawTitle?}` を返す純関数 |
+| `assignPageIds`         | URL リストから ディレクトリグループ採番ルールに従って `Map<url, id>` を組み立てる純関数   |
+| `buildPageIdLookup`     | `assignPageIds` の結果から `rewritePageRefs` 用ルックアップ表を一度だけ構築する純関数     |
+| `rewritePageRefs`       | 同一オリジンの asset/page 参照を root-relative path / `{{<id>}}` テンプレートに書き換える |
 
 `Frontmatter` の出力構造は [`./src/types.ts`](./src/types.ts) を参照。`title` / `og.title` / `twitter.title` は `｜` `|` で分割して最初の非空セグメントを採用し、分割が起きたときだけ `rawTitle` 等に元文字列を保持する。
 
@@ -83,13 +89,36 @@ import {
 - リソース URL とページ URL が衝突した場合は、ページ書き出しが後勝ちで上書きする（レイアウト剥がし後の HTML を canonical 版とみなすため）。
 - 出力 `.html` を直接ブラウザで開くと、frontmatter ブロックがページ先頭に visible text として表示され、DOCTYPE が先頭にないため Quirks Mode に落ちる。これは中間成果物として後続の scaffold パイプラインに渡す前提の挙動で、エンドユーザー向けのレンダリング対象ではない。
 
+### ページ id 採番と参照書き換え
+
+`extractPages` は処理開始時に `items` の全 URL を `assignPageIds` に渡して URL → 整数 id の写像を組み立てる。各ページの frontmatter には `id: <number>` がトップに埋め込まれ、本文中の同一オリジン参照は `rewritePageRefs` が次のルールで書き換える。
+
+採番ルール:
+
+- root セクション（pathname に副ディレクトリを含まない URL — `/`、`/foo.html`、`/foo` 等）: `5, 10, 15, …`
+- N 番目の第一階層サブディレクトリセクション（小文字化したディレクトリ名でアルファベット順）: `N×10000, +5, +10, …`
+
+セクション内のページ順序は `@d-zero/shared/sort/path` の `pathComparator`（nitpicker / kamado と同じ自然 URL 順）で安定化させ、サブディレクトリ名の順序は `@d-zero/shared/sort/alphabetical` の `alphabeticalComparator`（locale 非依存）で安定化させているので、同じアーカイブからは Node の ICU ビルドに関わらず毎回同じ id が割り当てられる。サブディレクトリ深さ 2 以上は最上位のディレクトリで section が決まり、それ以下の階層はセクション内の自然 URL 順に吸収される。step 5 / 10000 単位の間隔は、手動で id を挿入する余地を残すための慣習で、後段の scaffold パイプラインの期待値と合わせてある。1 セクションあたり 2000 ページが上限（`SECTION_STEP / PAGE_STEP`）で、超過するとエラーを投げる — 黙って id が次セクションに侵入するより明示的に失敗させる方を採る。
+
+参照書き換えルール（`rewritePageRefs`）:
+
+- ベース URL はページ自身の URL。`<base href>` は無視する。
+- 同一オリジン（host 完全一致）のみが書き換え対象。外部オリジン・`mailto:` / `tel:` / `sms:` / `javascript:` / `data:` / `blob:` / `vbscript:` / `file:` スキーム・`#fragment` だけ（先頭空白付きも含む）・空文字は触らない。
+- 次のタグ・属性の同一オリジン URL は、id 写像にヒットすれば `{{<id>}}` テンプレートに置換し `?query` / `#fragment` を末尾に保持する（`{{42}}?q=foo#top`）。id がなければ root-relative path にフォールバック。
+  - `<a href>`、`<form action>`、`<iframe src>`。
+  - `<link href>` のうち `rel` トークンに `canonical` / `alternate` / `prev` / `next` を含むもの（`rel="stylesheet"` / `"icon"` 等は asset 扱い）。
+- それ以外のアセット属性（`<img src>`, `<img srcset>`, `<script src>`, `<source src/srcset>`, `<embed src>`, `<video src/poster>`, `<audio src>`, `<track src>`、および `<link>` の非ページ用法）は同一オリジンであれば root-relative path に書き換える。
+- id 写像のルックアップは origin+pathname+search の完全一致を先に試し、ヒットしなければ trailing-slash を吸収した origin+pathname にフォールバックする。これにより `/list?p=1` / `/list?p=2` の両方が `pageIds` に登録されていれば各々別の id に解決され、片方しか無ければ pathname-only の fallback で拾われる。`<a href="/about">` と `pageIds` の `/about/` も双方向にマッチする。
+
+`rewritePageRefs` が例外を投げた場合は fail-soft で書き換え前の HTML を出力し、`onResult` の `extracted` / `fallback` outcome に `rewriteError` フィールドを乗せてレポートする（`migrate()` の `pagesRewriteFailed` で集計）。フロントマター付与・id 採番は HTML 書き換えと独立して走るので、片方が失敗してももう片方は影響を受けない。
+
 ### Frontmatter（DB ベース）
 
 `getFrontmatter` は `.nitpicker` DB の flat meta カラムを `Frontmatter` 型にマップする。`title` / `og.title` / `twitter.title` は `splitTitle` を通り、`｜` / `|` で先頭セグメントが抜き出されたら元文字列を `rawTitle` 等に保持する（DB に rawTitle カラムが存在しないため `title` 全文から生成）。空文字列 / null / whitespace-only カラムは出力から落とすので、`description: ""` のような placeholder は発生しない。
 
 `formatFrontmatter` は後続の scaffold パイプラインがそのまま消費できる YAML を生成する。og.\* / twitter.\* は nested map で、サブオブジェクト全体が空なら親キーも省略される。`twitter.url` は DB に対応カラムがないため型・出力ともに非対応（`og.url` で代替する慣習に従う）。
 
-`extractPages` は `extractMainContent` と `getFrontmatter` を並列実行し、生成した YAML ブロックを抽出 HTML の先頭に prepend してから書き出す。DB に該当 URL の行がない場合は frontmatter を prepend せず HTML だけを書き出す。`getFrontmatter` 自体が例外を投げた場合も fail-soft で HTML 本文は保存される（メタ取得失敗は本文保存より優先しない）。
+`extractPages` は `extractMainContent` と `getFrontmatter` を並列実行し、生成した YAML ブロックを抽出 HTML の先頭に prepend してから書き出す。整数 id は常に付与されるので「DB 行なし」のページでも `---\nid: <number>\n---\n` ブロックは出る。`getFrontmatter` が例外を投げた場合は fail-soft で id-only frontmatter と本文を書き出し、`onResult` の outcome に `metaError` を載せて警告する（`migrate()` レポートでは `pagesMetaFailed` として集計される）。
 
 ### 設計上の注意
 

--- a/packages/@d-zero/site-migrator/src/cli.ts
+++ b/packages/@d-zero/site-migrator/src/cli.ts
@@ -7,9 +7,11 @@ const USAGE = `Usage:
   dz-migrate <archive.nitpicker> -o <htdocs-dir> [--limit <n>] [--extract-limit <n>]
 
 Downloads sub-resources from the archive and, for each internal page, strips
-the shared layout and prepends a YAML frontmatter block sourced from the
-.nitpicker DB. Output files are intermediate artifacts for the scaffold
-pipeline, not for direct browser rendering.
+the shared layout, assigns a stable integer id, prepends a YAML frontmatter
+block (id + DB-sourced meta), and rewrites same-origin URL references inside
+the body (asset URLs → root-relative paths; <a href> / <form action> → the
+{{<id>}} template token consumed by the downstream scaffold pipeline). Output
+files are intermediate artifacts, not for direct browser rendering.
 
 Options:
   -o, --output <htdocs-dir>      Output destination. URL pathnames are mirrored verbatim
@@ -109,12 +111,25 @@ async function main(argv: readonly string[]): Promise<number> {
 					}
 					case 'missing': {
 						process.stderr.write(`miss: ${event.url} — archive has no snapshot\n`);
-						break;
+						return;
 					}
 					case 'failed': {
 						process.stderr.write(`fail: ${event.url} — ${event.error.message}\n`);
-						break;
+						return;
 					}
+				}
+				// Soft-error warnings sit outside the outcome switch because they
+				// can fire on both extracted and fallback events without changing
+				// the success classification.
+				if (event.rewriteError) {
+					process.stderr.write(
+						`warn: ${event.url} — rewrite failed, raw HTML kept: ${event.rewriteError.message}\n`,
+					);
+				}
+				if (event.metaError) {
+					process.stderr.write(
+						`warn: ${event.url} — meta read failed, id-only frontmatter kept: ${event.metaError.message}\n`,
+					);
 				}
 			},
 		});
@@ -129,7 +144,8 @@ async function main(argv: readonly string[]): Promise<number> {
 		const pagesSkipped = report.totalPages - pagesHandled;
 		process.stdout.write(
 			`\nResources: ${report.resourcesSaved} saved, ${report.resourcesFailed} failed, ${resourcesSkipped} skipped (out of ${report.totalResources}).\n` +
-				`Pages: ${report.pagesExtracted} extracted, ${report.pagesFallback} fallback, ${report.pagesMissing} missing, ${report.pagesFailed} failed, ${pagesSkipped} skipped (out of ${report.totalPages}).\n`,
+				`Pages: ${report.pagesExtracted} extracted, ${report.pagesFallback} fallback, ${report.pagesMissing} missing, ${report.pagesFailed} failed, ${pagesSkipped} skipped (out of ${report.totalPages}).\n` +
+				`Soft errors (body still written): ${report.pagesRewriteFailed} rewrite, ${report.pagesMetaFailed} meta.\n`,
 		);
 		if (controller.signal.aborted || resourcesSkipped > 0 || pagesSkipped > 0) {
 			return 130;

--- a/packages/@d-zero/site-migrator/src/html/format-frontmatter.spec.ts
+++ b/packages/@d-zero/site-migrator/src/html/format-frontmatter.spec.ts
@@ -77,4 +77,14 @@ describe('formatFrontmatter', () => {
 		// js-yaml double-quote rules escape `"` as `\"` and tab as `\t`.
 		expect(out).toContain('title: "Quote \\"inside\\" & Tab\\there"');
 	});
+
+	test('emits id at the top of the block as a bare integer (not quoted)', () => {
+		const out = formatFrontmatter({ id: 42, title: 'T' });
+		expect(out).toBe('---\nid: 42\ntitle: "T"\n---\n');
+	});
+
+	test('omits id when undefined', () => {
+		const out = formatFrontmatter({ title: 'T' });
+		expect(out).not.toContain('id:');
+	});
 });

--- a/packages/@d-zero/site-migrator/src/html/format-frontmatter.ts
+++ b/packages/@d-zero/site-migrator/src/html/format-frontmatter.ts
@@ -41,6 +41,7 @@ export function formatFrontmatter(meta: Frontmatter): string {
 }
 
 const TOP_LEVEL_KEYS = [
+	'id',
 	'title',
 	'rawTitle',
 	'description',

--- a/packages/@d-zero/site-migrator/src/html/rewrite-asset-refs.spec.ts
+++ b/packages/@d-zero/site-migrator/src/html/rewrite-asset-refs.spec.ts
@@ -46,4 +46,20 @@ describe('rewriteAssetRefs', () => {
 			{ url: '/y', attribute: 'href', tag: 'link' },
 		]);
 	});
+
+	test('forwards the start tag’s full attribute list so resolvers can branch on siblings (e.g. rel on <link>)', async () => {
+		const seen: { tag: string; href: string; rel: string | null }[] = [];
+		await rewriteAssetRefs(
+			'<link rel="icon" href="/icon.png">' + '<link rel="canonical" href="/about/">',
+			(url, _attr, tag, tagAttrs) => {
+				const rel = tagAttrs.find((a) => a.name === 'rel')?.value ?? null;
+				seen.push({ tag, href: url, rel });
+				return null;
+			},
+		);
+		expect(seen).toEqual([
+			{ tag: 'link', href: '/icon.png', rel: 'icon' },
+			{ tag: 'link', href: '/about/', rel: 'canonical' },
+		]);
+	});
 });

--- a/packages/@d-zero/site-migrator/src/html/rewrite-asset-refs.ts
+++ b/packages/@d-zero/site-migrator/src/html/rewrite-asset-refs.ts
@@ -37,6 +37,7 @@ export async function rewriteAssetRefs(
 					attribute.value,
 					attribute.name,
 					startTag.tagName,
+					startTag.attrs,
 					resolver,
 				);
 			}
@@ -52,12 +53,14 @@ export async function rewriteAssetRefs(
  * @param original
  * @param attributeName
  * @param tagName
+ * @param tagAttrs
  * @param resolver
  */
 function rewriteAttributeValue(
 	original: string,
 	attributeName: string,
 	tagName: string,
+	tagAttrs: readonly { name: string; value: string }[],
 	resolver: AssetResolver,
 ): string {
 	if (original === '') {
@@ -66,12 +69,12 @@ function rewriteAttributeValue(
 	if (attributeName === 'srcset') {
 		const candidates = parseSrcset(original);
 		const next = candidates.map(({ url, descriptor }) => {
-			const replaced = resolver(url, attributeName, tagName);
+			const replaced = resolver(url, attributeName, tagName, tagAttrs);
 			return { url: replaced ?? url, descriptor };
 		});
 		return serializeSrcset(next);
 	}
-	const replaced = resolver(original, attributeName, tagName);
+	const replaced = resolver(original, attributeName, tagName, tagAttrs);
 	return replaced ?? original;
 }
 

--- a/packages/@d-zero/site-migrator/src/index.ts
+++ b/packages/@d-zero/site-migrator/src/index.ts
@@ -34,6 +34,15 @@ export type {
 	ExtractPageResult,
 	ExtractPagesOptions,
 } from './page-extractor/extract-pages.js';
+export { assignPageIds } from './page-extractor/assign-page-ids.js';
+export {
+	buildPageIdLookup,
+	rewritePageRefs,
+} from './page-extractor/rewrite-page-refs.js';
+export type {
+	PageIdLookup,
+	RewritePageRefsOptions,
+} from './page-extractor/rewrite-page-refs.js';
 
 export { migrate } from './migrate.js';
 export type { MigrateOptions, MigrateReport } from './migrate.js';
@@ -41,6 +50,7 @@ export type { MigrateOptions, MigrateReport } from './migrate.js';
 export type {
 	ArchiveSession,
 	AssetResolver,
+	AssetResolverTagAttribute,
 	Frontmatter,
 	InternalPage,
 	InternalResource,

--- a/packages/@d-zero/site-migrator/src/migrate.spec.ts
+++ b/packages/@d-zero/site-migrator/src/migrate.spec.ts
@@ -19,12 +19,21 @@ vi.mock('./archive/get-page-html.js', () => ({
 vi.mock('./archive/get-frontmatter.js', () => ({
 	getFrontmatter: vi.fn(),
 }));
+type RewritePageRefsModule = typeof import('./page-extractor/rewrite-page-refs.js');
+vi.mock('./page-extractor/rewrite-page-refs.js', async (importOriginal) => {
+	const actual = await importOriginal<RewritePageRefsModule>();
+	return {
+		...actual,
+		rewritePageRefs: vi.fn(actual.rewritePageRefs),
+	};
+});
 
 const { openArchive } = await import('./archive/open-archive.js');
 const { listInternalResources } = await import('./archive/list-internal-resources.js');
 const { listInternalPages } = await import('./archive/list-internal-pages.js');
 const { getPageHtml } = await import('./archive/get-page-html.js');
 const { getFrontmatter } = await import('./archive/get-frontmatter.js');
+const { rewritePageRefs } = await import('./page-extractor/rewrite-page-refs.js');
 const { migrate } = await import('./migrate.js');
 
 const openArchiveMock = vi.mocked(openArchive);
@@ -32,6 +41,7 @@ const listInternalResourcesMock = vi.mocked(listInternalResources);
 const listInternalPagesMock = vi.mocked(listInternalPages);
 const getPageHtmlMock = vi.mocked(getPageHtml);
 const getFrontmatterMock = vi.mocked(getFrontmatter);
+const rewritePageRefsMock = vi.mocked(rewritePageRefs);
 
 const closeMock = vi.fn(() => Promise.resolve());
 
@@ -66,6 +76,11 @@ describe('migrate', () => {
 		getPageHtmlMock.mockReset();
 		getFrontmatterMock.mockReset();
 		getFrontmatterMock.mockResolvedValue(null);
+		rewritePageRefsMock.mockReset();
+		const real = await vi.importActual<RewritePageRefsModule>(
+			'./page-extractor/rewrite-page-refs.js',
+		);
+		rewritePageRefsMock.mockImplementation(real.rewritePageRefs);
 		closeMock.mockClear();
 
 		openArchiveMock.mockResolvedValue({
@@ -113,6 +128,8 @@ describe('migrate', () => {
 			pagesFallback: 0,
 			pagesMissing: 1,
 			pagesFailed: 0,
+			pagesRewriteFailed: 0,
+			pagesMetaFailed: 0,
 		});
 		expect(closeMock).toHaveBeenCalledTimes(1);
 	});
@@ -176,10 +193,10 @@ describe('migrate', () => {
 
 		expect(callOrder).toEqual(['fetch', 'getPageHtml']);
 		const written = await readFile(path.join(outputDir, 'p1.html'), 'utf8');
-		expect(written).toBe('<main>PAGE</main>');
+		expect(written).toBe('---\nid: 5\n---\n<main>PAGE</main>');
 	});
 
-	test('end-to-end: prepends YAML frontmatter to the extracted HTML when DB meta is available', async () => {
+	test('end-to-end: prepends YAML frontmatter (id + DB meta) to the extracted HTML', async () => {
 		listInternalResourcesMock.mockReturnValue(iter([]));
 		listInternalPagesMock.mockReturnValue(iter([{ url: 'https://example.com/p1' }]));
 		vi.stubGlobal('fetch', vi.fn());
@@ -195,8 +212,78 @@ describe('migrate', () => {
 
 		const written = await readFile(path.join(outputDir, 'p1.html'), 'utf8');
 		expect(written).toBe(
-			'---\ntitle: "P1"\nog:\n  title: "OG P1"\n---\n<main><p>body</p></main>',
+			'---\nid: 5\ntitle: "P1"\nog:\n  title: "OG P1"\n---\n<main><p>body</p></main>',
 		);
+	});
+
+	test('end-to-end: rewrites same-origin <a href> to {{<id>}} and assets to root-relative paths', async () => {
+		listInternalResourcesMock.mockReturnValue(iter([]));
+		listInternalPagesMock.mockReturnValue(
+			iter([
+				{ url: 'https://example.com/index.html' },
+				{ url: 'https://example.com/about/' },
+			]),
+		);
+		vi.stubGlobal('fetch', vi.fn());
+		getPageHtmlMock.mockResolvedValueOnce(
+			'<!doctype html><html><head></head><body><main>' +
+				'<a href="/about/">about</a>' +
+				'<img src="../img/logo.png">' +
+				'<a href="https://other.example/x">ext</a>' +
+				'</main></body></html>',
+		);
+		getPageHtmlMock.mockResolvedValueOnce(
+			'<!doctype html><html><head></head><body><main>body</main></body></html>',
+		);
+
+		await migrate({ archivePath: '/tmp/fake.nitpicker', outputDir });
+
+		const written = await readFile(path.join(outputDir, 'index.html'), 'utf8');
+		expect(written).toBe(
+			'---\nid: 5\n---\n<main>' +
+				'<a href="{{10000}}">about</a>' +
+				'<img src="/img/logo.png">' +
+				'<a href="https://other.example/x">ext</a>' +
+				'</main>',
+		);
+	});
+
+	test('counts pages whose rewritePageRefs rejection was surfaced as rewriteError under pagesRewriteFailed', async () => {
+		listInternalResourcesMock.mockReturnValue(iter([]));
+		listInternalPagesMock.mockReturnValue(iter([{ url: 'https://example.com/p1' }]));
+		vi.stubGlobal('fetch', vi.fn());
+		getPageHtmlMock.mockResolvedValueOnce(
+			'<!doctype html><html><head></head><body><main>x</main></body></html>',
+		);
+		rewritePageRefsMock.mockRejectedValueOnce(new Error('rewrite boom'));
+
+		const report = await migrate({ archivePath: '/tmp/fake.nitpicker', outputDir });
+
+		expect(report).toMatchObject({
+			pagesExtracted: 1,
+			pagesRewriteFailed: 1,
+			pagesMetaFailed: 0,
+		});
+	});
+
+	test('counts pages whose getFrontmatter rejection was surfaced as metaError under pagesMetaFailed', async () => {
+		listInternalResourcesMock.mockReturnValue(iter([]));
+		listInternalPagesMock.mockReturnValue(iter([{ url: 'https://example.com/p1' }]));
+		vi.stubGlobal('fetch', vi.fn());
+		getPageHtmlMock.mockResolvedValueOnce(
+			'<!doctype html><html><head></head><body><main>x</main></body></html>',
+		);
+		// Override the default `mockResolvedValue(null)` set in beforeEach.
+		getFrontmatterMock.mockReset();
+		getFrontmatterMock.mockRejectedValueOnce(new Error('sqlite boom'));
+
+		const report = await migrate({ archivePath: '/tmp/fake.nitpicker', outputDir });
+
+		expect(report).toMatchObject({
+			pagesExtracted: 1,
+			pagesMetaFailed: 1,
+			pagesRewriteFailed: 0,
+		});
 	});
 
 	test('closes the archive session even when the resource pipeline throws', async () => {

--- a/packages/@d-zero/site-migrator/src/migrate.ts
+++ b/packages/@d-zero/site-migrator/src/migrate.ts
@@ -34,6 +34,18 @@ export interface MigrateReport {
 	pagesFallback: number;
 	pagesMissing: number;
 	pagesFailed: number;
+	/**
+	 * Subset of `pagesExtracted` + `pagesFallback` whose `rewritePageRefs`
+	 * threw. The body was still written; surfaced here so programmatic
+	 * consumers can audit fail-soft rewrites without subscribing to `onPage`.
+	 */
+	pagesRewriteFailed: number;
+	/**
+	 * Subset of `pagesExtracted` + `pagesFallback` whose `getFrontmatter` read
+	 * threw. The id-only frontmatter was still written; surfaced for the same
+	 * reason as `pagesRewriteFailed`.
+	 */
+	pagesMetaFailed: number;
 }
 
 /**
@@ -97,6 +109,8 @@ export async function migrate(options: MigrateOptions): Promise<MigrateReport> {
 		let pagesFallback = 0;
 		let pagesMissing = 0;
 		let pagesFailed = 0;
+		let pagesRewriteFailed = 0;
+		let pagesMetaFailed = 0;
 		await extractPages({
 			session,
 			items: pageItems,
@@ -122,6 +136,18 @@ export async function migrate(options: MigrateOptions): Promise<MigrateReport> {
 						break;
 					}
 				}
+				if (
+					(event.outcome === 'extracted' || event.outcome === 'fallback') &&
+					event.rewriteError
+				) {
+					pagesRewriteFailed += 1;
+				}
+				if (
+					(event.outcome === 'extracted' || event.outcome === 'fallback') &&
+					event.metaError
+				) {
+					pagesMetaFailed += 1;
+				}
 				onPage?.(event);
 			},
 		});
@@ -135,6 +161,8 @@ export async function migrate(options: MigrateOptions): Promise<MigrateReport> {
 			pagesFallback,
 			pagesMissing,
 			pagesFailed,
+			pagesRewriteFailed,
+			pagesMetaFailed,
 		};
 	} finally {
 		await session.close();

--- a/packages/@d-zero/site-migrator/src/page-extractor/assign-page-ids.spec.ts
+++ b/packages/@d-zero/site-migrator/src/page-extractor/assign-page-ids.spec.ts
@@ -1,0 +1,142 @@
+import { describe, expect, test } from 'vitest';
+
+import { assignPageIds } from './assign-page-ids.js';
+
+describe('assignPageIds', () => {
+	test('assigns 5/10/15 to root pages sorted by pathComparator', () => {
+		const ids = assignPageIds([
+			'https://example.com/sorry.html',
+			'https://example.com/profile.html',
+			'https://example.com/index.html',
+			'https://example.com/maintenance.html',
+		]);
+
+		expect([...ids.entries()]).toStrictEqual([
+			['https://example.com/index.html', 5],
+			['https://example.com/maintenance.html', 10],
+			['https://example.com/profile.html', 15],
+			['https://example.com/sorry.html', 20],
+		]);
+	});
+
+	test('groups by first-level subdirectory and starts each section at N*10000', () => {
+		const ids = assignPageIds([
+			'https://example.com/products/index.html',
+			'https://example.com/products/about.html',
+			'https://example.com/news/1.html',
+			'https://example.com/news/2.html',
+			'https://example.com/news/10.html',
+		]);
+
+		expect(ids.get('https://example.com/news/1.html')).toBe(10_000);
+		expect(ids.get('https://example.com/news/2.html')).toBe(10_005);
+		// pathComparator does natural sort; 10 sorts after 2.
+		expect(ids.get('https://example.com/news/10.html')).toBe(10_010);
+		// products sorts after news, so section index is 2 → start at 20000.
+		// pathComparator puts `index` before regular names.
+		expect(ids.get('https://example.com/products/index.html')).toBe(20_000);
+		expect(ids.get('https://example.com/products/about.html')).toBe(20_005);
+	});
+
+	test('treats trailing-slash root URLs as root section', () => {
+		const ids = assignPageIds(['https://example.com/', 'https://example.com/about.html']);
+
+		expect(ids.get('https://example.com/')).toBe(5);
+		expect(ids.get('https://example.com/about.html')).toBe(10);
+	});
+
+	test('treats `/foo/` as a subdirectory section even when alone', () => {
+		const ids = assignPageIds([
+			'https://example.com/about/',
+			'https://example.com/index.html',
+		]);
+
+		expect(ids.get('https://example.com/index.html')).toBe(5);
+		expect(ids.get('https://example.com/about/')).toBe(10_000);
+	});
+
+	test('dedupes duplicate URLs by exact string equality', () => {
+		const ids = assignPageIds([
+			'https://example.com/a.html',
+			'https://example.com/a.html',
+			'https://example.com/b.html',
+		]);
+
+		expect(ids.size).toBe(2);
+		expect(ids.get('https://example.com/a.html')).toBe(5);
+		expect(ids.get('https://example.com/b.html')).toBe(10);
+	});
+
+	test('section index counts only subdirectory sections (root does not consume one)', () => {
+		const ids = assignPageIds([
+			'https://example.com/root.html',
+			'https://example.com/alpha/page.html',
+			'https://example.com/bravo/page.html',
+			'https://example.com/charlie/page.html',
+		]);
+
+		expect(ids.get('https://example.com/root.html')).toBe(5);
+		expect(ids.get('https://example.com/alpha/page.html')).toBe(10_000);
+		expect(ids.get('https://example.com/bravo/page.html')).toBe(20_000);
+		expect(ids.get('https://example.com/charlie/page.html')).toBe(30_000);
+	});
+
+	test('drops unparsable URLs silently', () => {
+		const ids = assignPageIds(['not a url', 'https://example.com/index.html']);
+
+		expect(ids.size).toBe(1);
+		expect(ids.get('https://example.com/index.html')).toBe(5);
+	});
+
+	test('sorts subdirectory section names case-insensitively', () => {
+		const ids = assignPageIds([
+			'https://example.com/Beta/page.html',
+			'https://example.com/alpha/page.html',
+		]);
+
+		expect(ids.get('https://example.com/alpha/page.html')).toBe(10_000);
+		expect(ids.get('https://example.com/Beta/page.html')).toBe(20_000);
+	});
+
+	test('throws when a section would exceed the 2000-page id-range, instead of silently colliding with the next section', () => {
+		const urls = Array.from(
+			{ length: 2001 },
+			(_, i) => `https://example.com/section/${i}.html`,
+		);
+		expect(() => assignPageIds(urls)).toThrow(/section "section" has 2001 pages/);
+	});
+
+	test('accepts exactly 2000 pages in a section without throwing (boundary)', () => {
+		const urls = Array.from(
+			{ length: 2000 },
+			(_, i) => `https://example.com/section/${i}.html`,
+		);
+		// Must not throw; the last id must stay strictly below the next section's
+		// base (20_000) so peer-section ids never collide.
+		const ids = assignPageIds(urls);
+		const maxId = Math.max(...ids.values());
+		expect(maxId).toBeLessThan(20_000);
+	});
+
+	test('throws for the same reason when the root section overflows', () => {
+		const urls = Array.from(
+			{ length: 2001 },
+			(_, i) => `https://example.com/page-${i}.html`,
+		);
+		expect(() => assignPageIds(urls)).toThrow(/section "root" has 2001 pages/);
+	});
+
+	test('output is stable regardless of input order', () => {
+		const inputA = [
+			'https://example.com/index.html',
+			'https://example.com/foo/a.html',
+			'https://example.com/bar/b.html',
+		];
+		const inputB = inputA.toReversed();
+
+		const idsA = assignPageIds(inputA);
+		const idsB = assignPageIds(inputB);
+
+		expect([...idsA.entries()].toSorted()).toStrictEqual([...idsB.entries()].toSorted());
+	});
+});

--- a/packages/@d-zero/site-migrator/src/page-extractor/assign-page-ids.ts
+++ b/packages/@d-zero/site-migrator/src/page-extractor/assign-page-ids.ts
@@ -1,0 +1,154 @@
+import { alphabeticalComparator } from '@d-zero/shared/sort/alphabetical';
+import { pathComparator } from '@d-zero/shared/sort/path';
+
+/**
+ * Maximum number of pages allowed in a single section before its id range
+ * overlaps the next section. `sectionIndex * SECTION_STEP + pageIndex *
+ * PAGE_STEP` overflows when `pageIndex * PAGE_STEP >= SECTION_STEP`, so the
+ * safe upper bound is `SECTION_STEP / PAGE_STEP`.
+ */
+const SECTION_STEP = 10_000;
+const PAGE_STEP = 5;
+const MAX_PAGES_PER_SECTION = SECTION_STEP / PAGE_STEP;
+
+/**
+ * Build a deterministic URL → integer-id map following the directory-grouped
+ * numbering scheme used by the downstream scaffold pipeline.
+ *
+ * Why this scheme: ids are sparse (step 5) so editors can insert pages without
+ * renumbering, and grouping by first-level directory keeps related pages
+ * visually clustered when sorted by id. The exact step values match the
+ * scaffold's expectations so the migrator's output can be ingested without an
+ * adapter layer.
+ *
+ * Sectioning:
+ *
+ * - Root section — URLs whose pathname has no implied subdirectory (`/`,
+ *   `/foo.html`, `/foo`). Receives ids `5, 10, 15, …`.
+ * - N-th first-level subdirectory section — URLs whose pathname's first segment
+ *   names a directory (`/about/`, `/foo/bar.html`). Subdirectories are sorted
+ *   case-insensitively by name to produce the section index `N` (starting at
+ *   1). Pages inside the section receive ids `N×10000, N×10000+5, …`.
+ *
+ * Within each section, URLs are sorted with {@link pathComparator} (the same
+ * comparator nitpicker / kamado use for natural URL ordering) so the ids stay
+ * stable across runs.
+ *
+ * Duplicate URLs are deduped by exact string equality before assignment;
+ * unparsable URLs are silently dropped (they would not survive the rest of the
+ * pipeline either).
+ * @param urls
+ * @example
+ * assignPageIds([
+ *   'https://example.com/',
+ *   'https://example.com/about/',
+ *   'https://example.com/news/2024.html',
+ * ])
+ * // Map(3) {
+ * //   'https://example.com/' => 5,
+ * //   'https://example.com/about/' => 10000,
+ * //   'https://example.com/news/2024.html' => 20000,
+ * // }
+ */
+export function assignPageIds(urls: readonly string[]): Map<string, number> {
+	const sections = new Map<string, string[]>();
+	const seen = new Set<string>();
+
+	for (const url of urls) {
+		if (seen.has(url)) {
+			continue;
+		}
+		seen.add(url);
+
+		const section = sectionFor(url);
+		if (section === null) {
+			continue;
+		}
+		const bucket = sections.get(section) ?? [];
+		bucket.push(url);
+		sections.set(section, bucket);
+	}
+
+	for (const [section, bucket] of sections) {
+		sections.set(section, bucket.toSorted(pathComparator));
+	}
+
+	// Section keys are already lowercased by `sectionFor`, so the comparator
+	// reduces to plain alphabetical ordering. Use `alphabeticalComparator`
+	// (decodeURI-aware, locale-independent) rather than `localeCompare`, which
+	// depends on the host's ICU build and would shuffle non-ASCII section
+	// names between dev/CI environments — breaking the docstring's
+	// "same archive always produces the same ids" guarantee.
+	const subdirectoryNames = [...sections.keys()]
+		.filter((name) => name !== '')
+		.toSorted(alphabeticalComparator);
+
+	const ids = new Map<string, number>();
+
+	const rootBucket = sections.get('');
+	if (rootBucket) {
+		assertSectionFits('root', rootBucket.length);
+		for (const [index, url] of rootBucket.entries()) {
+			ids.set(url, (index + 1) * PAGE_STEP);
+		}
+	}
+
+	for (const [subdirectoryIndex, name] of subdirectoryNames.entries()) {
+		const sectionIndex = subdirectoryIndex + 1;
+		const bucket = sections.get(name) ?? [];
+		assertSectionFits(name, bucket.length);
+		for (const [pageIndex, url] of bucket.entries()) {
+			ids.set(url, sectionIndex * SECTION_STEP + pageIndex * PAGE_STEP);
+		}
+	}
+
+	return ids;
+}
+
+/**
+ * Throws when a section would exceed `MAX_PAGES_PER_SECTION` pages — at which
+ * point the last page's id collides with the next section's first id. We
+ * prefer a loud failure to silent aliasing because the only way to recover the
+ * full URL → id map after a collision is to re-run with a larger SECTION_STEP.
+ * @param sectionName
+ * @param size
+ */
+function assertSectionFits(sectionName: string, size: number): void {
+	if (size > MAX_PAGES_PER_SECTION) {
+		throw new Error(
+			`assignPageIds: section ${JSON.stringify(sectionName)} has ${size} pages, ` +
+				`exceeding the ${MAX_PAGES_PER_SECTION}-page limit imposed by ` +
+				`SECTION_STEP=${SECTION_STEP} / PAGE_STEP=${PAGE_STEP}; ids would collide ` +
+				`with the next section. Reduce the section, or widen the step constants.`,
+		);
+	}
+}
+
+/**
+ * Returns the section key for `url`:
+ * - `''` for the root section (pathname has no implied subdirectory).
+ * - The first pathname segment (lowercased) for a subdirectory section.
+ * - `null` when the URL cannot be parsed.
+ *
+ * Implied-subdirectory rule: a URL is treated as living inside a subdirectory
+ * when its pathname has more than one non-empty segment OR ends with `/` after
+ * a single segment (so `/about/` groups under `about`, while `/about.html` and
+ * `/about` stay at root).
+ * @param url
+ */
+function sectionFor(url: string): string | null {
+	let parsed: URL;
+	try {
+		parsed = new URL(url);
+	} catch {
+		return null;
+	}
+	const segments = parsed.pathname.split('/').filter((segment) => segment !== '');
+	if (segments.length === 0) {
+		return '';
+	}
+	if (segments.length === 1 && !parsed.pathname.endsWith('/')) {
+		return '';
+	}
+	return segments[0]!.toLowerCase();
+}

--- a/packages/@d-zero/site-migrator/src/page-extractor/extract-pages.spec.ts
+++ b/packages/@d-zero/site-migrator/src/page-extractor/extract-pages.spec.ts
@@ -8,17 +8,28 @@ import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 
 import { extractPages, type ExtractPageResult } from './extract-pages.js';
 
+type RewritePageRefsModule = typeof import('./rewrite-page-refs.js');
+
 vi.mock('../archive/get-page-html.js', () => ({
 	getPageHtml: vi.fn(),
 }));
 vi.mock('../archive/get-frontmatter.js', () => ({
 	getFrontmatter: vi.fn(),
 }));
+vi.mock('./rewrite-page-refs.js', async (importOriginal) => {
+	const actual = await importOriginal<RewritePageRefsModule>();
+	return {
+		...actual,
+		rewritePageRefs: vi.fn(actual.rewritePageRefs),
+	};
+});
 
 const { getPageHtml } = await import('../archive/get-page-html.js');
 const { getFrontmatter } = await import('../archive/get-frontmatter.js');
+const { rewritePageRefs } = await import('./rewrite-page-refs.js');
 const getPageHtmlMock = vi.mocked(getPageHtml);
 const getFrontmatterMock = vi.mocked(getFrontmatter);
+const rewritePageRefsMock = vi.mocked(rewritePageRefs);
 
 const FAKE_SESSION = {
 	archiveId: 'test',
@@ -38,9 +49,12 @@ describe('extractPages', () => {
 		outputDir = await mkdtemp(path.join(tmpdir(), 'site-migrator-pages-'));
 		getPageHtmlMock.mockReset();
 		getFrontmatterMock.mockReset();
-		// Default: no DB row → no frontmatter prepended, keeping unrelated tests
-		// focused on extractMainContent behaviour rather than YAML output.
+		// Default: no DB row → only the id is emitted in frontmatter.
 		getFrontmatterMock.mockResolvedValue(null);
+		// Default: delegate to the real rewriter so other tests exercise it.
+		// Override per-test to force a rewrite failure.
+		const real = await vi.importActual<RewritePageRefsModule>('./rewrite-page-refs.js');
+		rewritePageRefsMock.mockImplementation(real.rewritePageRefs);
 	});
 
 	afterEach(async () => {
@@ -70,7 +84,8 @@ describe('extractPages', () => {
 			},
 		]);
 		const written = await readFile(path.join(outputDir, 'about', 'index.html'), 'utf8');
-		expect(written).toBe('<main><p>hello</p></main>');
+		// `/about/` is the only page in its subdirectory section → id 10000.
+		expect(written).toBe('---\nid: 10000\n---\n<main><p>hello</p></main>');
 	});
 
 	test('writes the original document when no rung matches (outcome=fallback)', async () => {
@@ -94,7 +109,7 @@ describe('extractPages', () => {
 			},
 		]);
 		const written = await readFile(path.join(outputDir, 'x.html'), 'utf8');
-		expect(written).toBe(original);
+		expect(written).toBe(`---\nid: 5\n---\n${original}`);
 	});
 
 	test('emits outcome=missing without writing to disk when archive returns null', async () => {
@@ -189,7 +204,7 @@ describe('extractPages', () => {
 
 		const written = await readFile(path.join(outputDir, 'p.html'), 'utf8');
 		expect(written).toBe(
-			'---\ntitle: "Page"\nog:\n  title: "OG Page"\n---\n<main><p>body</p></main>',
+			'---\nid: 5\ntitle: "Page"\nog:\n  title: "OG Page"\n---\n<main><p>body</p></main>',
 		);
 	});
 
@@ -209,10 +224,10 @@ describe('extractPages', () => {
 
 		expect(results[0]).toMatchObject({ outcome: 'fallback' });
 		const written = await readFile(path.join(outputDir, 'p.html'), 'utf8');
-		expect(written).toBe(`---\ntitle: "Page"\nlang: "ja"\n---\n${fullDoc}`);
+		expect(written).toBe(`---\nid: 5\ntitle: "Page"\nlang: "ja"\n---\n${fullDoc}`);
 	});
 
-	test('omits the frontmatter block entirely when the DB has no row (getFrontmatter null)', async () => {
+	test('emits an id-only frontmatter block when the DB has no row (getFrontmatter null)', async () => {
 		getPageHtmlMock.mockResolvedValueOnce(docWith('<main><p>x</p></main>'));
 		getFrontmatterMock.mockResolvedValueOnce(null);
 
@@ -224,12 +239,13 @@ describe('extractPages', () => {
 		});
 
 		const written = await readFile(path.join(outputDir, 'p.html'), 'utf8');
-		expect(written).toBe('<main><p>x</p></main>');
+		expect(written).toBe('---\nid: 5\n---\n<main><p>x</p></main>');
 	});
 
-	test('fails soft when getFrontmatter errors: the HTML is still written without a frontmatter block', async () => {
+	test('fails soft when getFrontmatter errors: the id-only frontmatter is still emitted', async () => {
 		// Meta is best-effort — a transient SQLite contention should not lose
-		// the page's already-extracted HTML body.
+		// the page's already-extracted HTML body, but the id we computed up
+		// front does not depend on the DB read.
 		getPageHtmlMock.mockResolvedValueOnce(docWith('<main><p>x</p></main>'));
 		getFrontmatterMock.mockRejectedValueOnce(new Error('db boom'));
 
@@ -248,7 +264,89 @@ describe('extractPages', () => {
 			outcome: 'extracted',
 		});
 		const written = await readFile(path.join(outputDir, 'p.html'), 'utf8');
-		expect(written).toBe('<main><p>x</p></main>');
+		expect(written).toBe('---\nid: 5\n---\n<main><p>x</p></main>');
+	});
+
+	test('rewrites same-origin <a href> to the id template using the items-derived id map', async () => {
+		getPageHtmlMock.mockResolvedValueOnce(
+			docWith('<main><a href="/about/">about</a></main>'),
+		);
+
+		await extractPages({
+			session: FAKE_SESSION,
+			items: [
+				{ url: 'https://example.com/index.html' },
+				{ url: 'https://example.com/about/' },
+			],
+			outputDir,
+			limit: 2,
+		});
+
+		const written = await readFile(path.join(outputDir, 'index.html'), 'utf8');
+		// `/index.html` is root section → id 5, `/about/` is subdir section 1 → id 10000.
+		expect(written).toBe('---\nid: 5\n---\n<main><a href="{{10000}}">about</a></main>');
+	});
+
+	test('fail-soft on rewritePageRefs throw: writes pre-rewrite HTML and surfaces rewriteError on the outcome', async () => {
+		getPageHtmlMock.mockResolvedValueOnce(
+			docWith('<main><a href="/about/">about</a></main>'),
+		);
+		rewritePageRefsMock.mockRejectedValueOnce(new Error('parse5 boom'));
+
+		const results: ExtractPageResult[] = [];
+		await extractPages({
+			session: FAKE_SESSION,
+			items: [{ url: 'https://example.com/p' }],
+			outputDir,
+			limit: 1,
+			onResult: (event) => results.push(event),
+		});
+
+		expect(results).toHaveLength(1);
+		expect(results[0]).toMatchObject({
+			url: 'https://example.com/p',
+			outcome: 'extracted',
+			rewriteError: { message: 'parse5 boom' },
+		});
+		const written = await readFile(path.join(outputDir, 'p.html'), 'utf8');
+		// Body is the un-rewritten extracted fragment (no {{id}} substitution).
+		expect(written).toBe('---\nid: 5\n---\n<main><a href="/about/">about</a></main>');
+	});
+
+	test('surfaces getFrontmatter rejection as metaError on the outcome (id-only frontmatter still written)', async () => {
+		getPageHtmlMock.mockResolvedValueOnce(docWith('<main><p>x</p></main>'));
+		getFrontmatterMock.mockRejectedValueOnce(new Error('sqlite contention'));
+
+		const results: ExtractPageResult[] = [];
+		await extractPages({
+			session: FAKE_SESSION,
+			items: [{ url: 'https://example.com/p' }],
+			outputDir,
+			limit: 1,
+			onResult: (event) => results.push(event),
+		});
+
+		expect(results[0]).toMatchObject({
+			url: 'https://example.com/p',
+			outcome: 'extracted',
+			metaError: { message: 'sqlite contention' },
+		});
+	});
+
+	test('rewrites same-origin asset URLs to root-relative paths', async () => {
+		getPageHtmlMock.mockResolvedValueOnce(
+			docWith('<main><img src="../img/a.png"></main>'),
+		);
+
+		await extractPages({
+			session: FAKE_SESSION,
+			items: [{ url: 'https://example.com/sub/page.html' }],
+			outputDir,
+			limit: 1,
+		});
+
+		const written = await readFile(path.join(outputDir, 'sub', 'page.html'), 'utf8');
+		expect(written).toBe('---\nid: 10000\n---\n<main><img src="/img/a.png"></main>');
 	});
 
 	test('returns immediately and writes nothing when signal is already aborted', async () => {

--- a/packages/@d-zero/site-migrator/src/page-extractor/extract-pages.ts
+++ b/packages/@d-zero/site-migrator/src/page-extractor/extract-pages.ts
@@ -12,6 +12,9 @@ import { urlToOutputPath } from '../downloader/url-to-output-path.js';
 import { extractMainContent } from '../html/extract-main-content.js';
 import { formatFrontmatter } from '../html/format-frontmatter.js';
 
+import { assignPageIds } from './assign-page-ids.js';
+import { buildPageIdLookup, rewritePageRefs } from './rewrite-page-refs.js';
+
 /**
  * Single page to extract. Wrapped as an object so `@d-zero/dealer` (which
  * requires `T extends WeakKey`) can track progress against it.
@@ -36,11 +39,27 @@ export type ExtractPageResult =
 			outcome: 'extracted';
 			outputPath: string;
 			matchedBy: ExtractMainCriterion;
+			/**
+			 * Present only when {@link rewritePageRefs} threw. The page body was
+			 * still written (fail-soft), but with original asset / page references
+			 * instead of the rewritten ones.
+			 */
+			rewriteError?: Error;
+			/**
+			 * Present only when {@link getFrontmatter} threw. The page body was
+			 * still written and the id-only frontmatter still prepended, but the
+			 * DB-sourced meta (title / description / og / …) is missing.
+			 */
+			metaError?: Error;
 	  }
 	| {
 			url: string;
 			outcome: 'fallback';
 			outputPath: string;
+			/** See `extracted.rewriteError`. */
+			rewriteError?: Error;
+			/** See `extracted.metaError`. */
+			metaError?: Error;
 	  }
 	| {
 			url: string;
@@ -55,8 +74,9 @@ export type ExtractPageResult =
 /**
  * For each page URL, reads the HTML snapshot from the archive, strips the
  * shared layout via {@link extractMainContent}, reads the per-page metadata
- * from the `.nitpicker` DB via {@link getFrontmatter}, and writes the result
- * to disk under `outputDir` mirroring the URL pathname.
+ * from the `.nitpicker` DB via {@link getFrontmatter}, rewrites same-origin
+ * URL references via {@link rewritePageRefs}, and writes the result to disk
+ * under `outputDir` mirroring the URL pathname.
  *
  * Mirrors {@link import('../downloader/download-resources.js').downloadResources}
  * in shape: failures (including pages absent from the archive) are surfaced via
@@ -64,12 +84,20 @@ export type ExtractPageResult =
  *
  * Output layout per file:
  *
- * - A `---\n…\n---\n` YAML frontmatter block is prepended whenever the DB
- *   yields any non-empty meta. If the DB has no row for the URL, or every
- *   meta column is empty, no frontmatter block is written.
+ * - A `---\n…\n---\n` YAML frontmatter block is prepended. It always carries
+ *   the page's integer `id` assigned by {@link assignPageIds}, plus any
+ *   non-empty meta from the DB. The id is the only mandatory field.
  * - The body that follows depends on the outcome:
  *   - `extracted` — the matched element's `outerHTML` fragment.
  *   - `fallback` — the entire original document, DOCTYPE included.
+ * - In both cases same-origin URLs are rewritten: `<a href>` / `<form action>`
+ *   pointing at a known page → `{{<id>}}<query><fragment>`; other same-origin
+ *   asset references → root-relative paths. Cross-origin URLs are left
+ *   untouched.
+ *
+ * Rewrite failure is fail-soft: the original HTML body is written and
+ * `rewriteError` is set on the result so the caller can log a warning without
+ * losing the page.
  * @param options
  */
 export async function extractPages(options: ExtractPagesOptions): Promise<void> {
@@ -123,6 +151,14 @@ export async function extractPages(options: ExtractPagesOptions): Promise<void> 
 	}
 	await Promise.all([...directories].map((dir) => mkdir(dir, { recursive: true })));
 
+	// Build the URL → id map up front from the full items list. Each page's id
+	// stays stable even when only a subset of pages succeeds, because the map
+	// is computed before any page worker runs. Build the pre-keyed lookup once
+	// alongside it so per-page rewritePageRefs calls don't pay an O(N²)
+	// rebuild.
+	const pageIds = assignPageIds(items.map((item) => item.url));
+	const pageIdLookup = buildPageIdLookup(pageIds);
+
 	await deal(
 		prepared,
 		(entry) => async () => {
@@ -152,22 +188,58 @@ export async function extractPages(options: ExtractPagesOptions): Promise<void> 
 					onResult?.({ url: entry.url, outcome: 'missing' });
 					return;
 				}
-				const result = extractMainContent(html);
+				const extracted = extractMainContent(html);
+				const id = pageIds.get(entry.url);
+
+				let bodyHtml = extracted.html;
+				let rewriteError: Error | undefined;
+				try {
+					bodyHtml = await rewritePageRefs({
+						html: extracted.html,
+						baseUrl: entry.url,
+						pageIdLookup,
+					});
+				} catch (error) {
+					rewriteError = error instanceof Error ? error : new Error(String(error));
+				}
+
 				const meta = metaSettled.status === 'fulfilled' ? metaSettled.value : null;
-				const frontmatterBlock = meta === null ? '' : formatFrontmatter(meta);
-				await writeFile(entry.outputPath, frontmatterBlock + result.html, 'utf8');
-				if (result.matched && result.matchedBy !== undefined) {
+				const metaError =
+					metaSettled.status === 'rejected'
+						? metaSettled.reason instanceof Error
+							? metaSettled.reason
+							: new Error(String(metaSettled.reason))
+						: undefined;
+				// Spread `meta` first so the computed integer id always wins over a
+				// stray `id` field the DB might one day surface — keeping the
+				// frontmatter id consistent with the {{<id>}} tokens rewritePageRefs
+				// emits on peer pages.
+				const frontmatterMeta = id === undefined ? meta : { ...meta, id };
+				// `frontmatterMeta === null` only happens when assignPageIds dropped
+				// the URL (unparsable) AND getFrontmatter returned no row; the page
+				// is still written body-only so downstream callers can decide what
+				// to do with the orphan.
+				const frontmatterBlock =
+					frontmatterMeta === null ? '' : formatFrontmatter(frontmatterMeta);
+
+				await writeFile(entry.outputPath, frontmatterBlock + bodyHtml, 'utf8');
+				const softErrors: { rewriteError?: Error; metaError?: Error } = {};
+				if (rewriteError) softErrors.rewriteError = rewriteError;
+				if (metaError) softErrors.metaError = metaError;
+				if (extracted.matched && extracted.matchedBy !== undefined) {
 					onResult?.({
 						url: entry.url,
 						outcome: 'extracted',
 						outputPath: entry.outputPath,
-						matchedBy: result.matchedBy,
+						matchedBy: extracted.matchedBy,
+						...softErrors,
 					});
 				} else {
 					onResult?.({
 						url: entry.url,
 						outcome: 'fallback',
 						outputPath: entry.outputPath,
+						...softErrors,
 					});
 				}
 			} catch (error) {

--- a/packages/@d-zero/site-migrator/src/page-extractor/rewrite-page-refs.spec.ts
+++ b/packages/@d-zero/site-migrator/src/page-extractor/rewrite-page-refs.spec.ts
@@ -1,0 +1,209 @@
+import { describe, expect, test } from 'vitest';
+
+import { buildPageIdLookup, rewritePageRefs } from './rewrite-page-refs.js';
+
+const BASE = 'https://example.com/about/';
+
+const lookupFrom = (entries: readonly (readonly [string, number])[]) =>
+	buildPageIdLookup(new Map(entries));
+
+describe('rewritePageRefs', () => {
+	test('rewrites same-origin <a href> to the id template', async () => {
+		const html = await rewritePageRefs({
+			html: '<a href="/news/">news</a>',
+			baseUrl: BASE,
+			pageIdLookup: lookupFrom([['https://example.com/news/', 42]]),
+		});
+		expect(html).toBe('<a href="{{42}}">news</a>');
+	});
+
+	test('preserves query and fragment when rewriting page refs', async () => {
+		const html = await rewritePageRefs({
+			html: '<a href="/news/?q=foo#top">news</a>',
+			baseUrl: BASE,
+			pageIdLookup: lookupFrom([['https://example.com/news/', 42]]),
+		});
+		expect(html).toBe('<a href="{{42}}?q=foo#top">news</a>');
+	});
+
+	test('falls back to root-relative path when no id mapping exists', async () => {
+		const html = await rewritePageRefs({
+			html: '<a href="/missing.html">x</a>',
+			baseUrl: BASE,
+			pageIdLookup: lookupFrom([]),
+		});
+		expect(html).toBe('<a href="/missing.html">x</a>');
+	});
+
+	test('rewrites relative same-origin asset URLs to root-relative paths', async () => {
+		const html = await rewritePageRefs({
+			html: '<img src="../img/a.png">',
+			baseUrl: BASE,
+			pageIdLookup: lookupFrom([]),
+		});
+		expect(html).toBe('<img src="/img/a.png">');
+	});
+
+	test('rewrites absolute same-origin asset URLs to root-relative paths', async () => {
+		const html = await rewritePageRefs({
+			html: '<script src="https://example.com/js/a.js"></script>',
+			baseUrl: BASE,
+			pageIdLookup: lookupFrom([]),
+		});
+		expect(html).toBe('<script src="/js/a.js"></script>');
+	});
+
+	test('keeps cross-origin URLs untouched', async () => {
+		const html = await rewritePageRefs({
+			html:
+				'<a href="https://other.example/x">x</a>' + '<img src="https://cdn.other/y.png">',
+			baseUrl: BASE,
+			pageIdLookup: lookupFrom([['https://other.example/x', 99]]),
+		});
+		expect(html).toBe(
+			'<a href="https://other.example/x">x</a>' + '<img src="https://cdn.other/y.png">',
+		);
+	});
+
+	test('keeps mailto:/tel:/javascript:/data: untouched', async () => {
+		const html = await rewritePageRefs({
+			html:
+				'<a href="mailto:a@example.com">m</a>' +
+				'<a href="tel:+81-3-0000">t</a>' +
+				'<a href="javascript:void(0)">j</a>' +
+				'<img src="data:image/png;base64,abc">',
+			baseUrl: BASE,
+			pageIdLookup: lookupFrom([]),
+		});
+		expect(html).toBe(
+			'<a href="mailto:a@example.com">m</a>' +
+				'<a href="tel:+81-3-0000">t</a>' +
+				'<a href="javascript:void(0)">j</a>' +
+				'<img src="data:image/png;base64,abc">',
+		);
+	});
+
+	test('keeps bare-fragment same-page anchors untouched', async () => {
+		const html = await rewritePageRefs({
+			html: '<a href="#section">jump</a>',
+			baseUrl: BASE,
+			pageIdLookup: lookupFrom([]),
+		});
+		expect(html).toBe('<a href="#section">jump</a>');
+	});
+
+	test('keeps whitespace-padded bare-fragment anchors untouched', async () => {
+		const html = await rewritePageRefs({
+			html: '<a href=" #section">jump</a>',
+			baseUrl: BASE,
+			pageIdLookup: lookupFrom([['https://example.com/about/', 7]]),
+		});
+		// The leading space-fragment must NOT be rewritten to {{<own-id>}}#section.
+		expect(html).toBe('<a href=" #section">jump</a>');
+	});
+
+	test('rewrites <form action> the same way as <a href>', async () => {
+		const html = await rewritePageRefs({
+			html: '<form action="/contact/"></form>',
+			baseUrl: BASE,
+			pageIdLookup: lookupFrom([['https://example.com/contact/', 7]]),
+		});
+		expect(html).toBe('<form action="{{7}}"></form>');
+	});
+
+	test('rewrites <iframe src> as a page reference', async () => {
+		const html = await rewritePageRefs({
+			html: '<iframe src="/widget/"></iframe>',
+			baseUrl: BASE,
+			pageIdLookup: lookupFrom([['https://example.com/widget/', 11]]),
+		});
+		expect(html).toBe('<iframe src="{{11}}"></iframe>');
+	});
+
+	test('rewrites <link rel="canonical" href> as a page reference', async () => {
+		const html = await rewritePageRefs({
+			html: '<link rel="canonical" href="/about/">',
+			baseUrl: BASE,
+			pageIdLookup: lookupFrom([['https://example.com/about/', 13]]),
+		});
+		expect(html).toBe('<link rel="canonical" href="{{13}}">');
+	});
+
+	test.each(['alternate', 'prev', 'next'])(
+		'rewrites <link rel="%s" href> as a page reference',
+		async (rel) => {
+			const html = await rewritePageRefs({
+				html: `<link rel="${rel}" href="/p/">`,
+				baseUrl: BASE,
+				pageIdLookup: lookupFrom([['https://example.com/p/', 21]]),
+			});
+			expect(html).toBe(`<link rel="${rel}" href="{{21}}">`);
+		},
+	);
+
+	test('treats <link rel="stylesheet"|"icon"> href as an asset (root-relative path, NOT id template)', async () => {
+		const html = await rewritePageRefs({
+			html:
+				'<link rel="stylesheet" href="/css/site.css">' +
+				'<link rel="icon" href="/favicon.ico">',
+			baseUrl: BASE,
+			pageIdLookup: lookupFrom([
+				['https://example.com/css/site.css', 30],
+				['https://example.com/favicon.ico', 31],
+			]),
+		});
+		expect(html).toBe(
+			'<link rel="stylesheet" href="/css/site.css">' +
+				'<link rel="icon" href="/favicon.ico">',
+		);
+	});
+
+	test('rewrites srcset URL candidates while preserving descriptors', async () => {
+		const html = await rewritePageRefs({
+			html: '<img srcset="/a.png 1x, /b.png 2x">',
+			baseUrl: BASE,
+			pageIdLookup: lookupFrom([]),
+		});
+		expect(html).toBe('<img srcset="/a.png 1x, /b.png 2x">');
+	});
+
+	test('returns the original HTML when baseUrl is not parseable', async () => {
+		const original = '<a href="/x">x</a>';
+		const html = await rewritePageRefs({
+			html: original,
+			baseUrl: 'not a url',
+			pageIdLookup: lookupFrom([]),
+		});
+		expect(html).toBe(original);
+	});
+
+	test('absorbs trailing-slash drift: items registered with `/about/` match a link to `/about`', async () => {
+		const html = await rewritePageRefs({
+			html: '<a href="/about">about</a>',
+			baseUrl: BASE,
+			pageIdLookup: lookupFrom([['https://example.com/about/', 9]]),
+		});
+		expect(html).toBe('<a href="{{9}}">about</a>');
+	});
+
+	test('absorbs trailing-slash drift: items registered with `/about` match a link to `/about/`', async () => {
+		const html = await rewritePageRefs({
+			html: '<a href="/about/">about</a>',
+			baseUrl: BASE,
+			pageIdLookup: lookupFrom([['https://example.com/about', 9]]),
+		});
+		expect(html).toBe('<a href="{{9}}">about</a>');
+	});
+
+	test('exact-query lookup wins over pathname-only fallback when both `?p=1` and `?p=2` are mapped', async () => {
+		const html = await rewritePageRefs({
+			html: '<a href="/list?p=1">a</a><a href="/list?p=2">b</a>',
+			baseUrl: BASE,
+			pageIdLookup: lookupFrom([
+				['https://example.com/list?p=1', 5],
+				['https://example.com/list?p=2', 10],
+			]),
+		});
+		expect(html).toBe('<a href="{{5}}?p=1">a</a><a href="{{10}}?p=2">b</a>');
+	});
+});

--- a/packages/@d-zero/site-migrator/src/page-extractor/rewrite-page-refs.ts
+++ b/packages/@d-zero/site-migrator/src/page-extractor/rewrite-page-refs.ts
@@ -1,0 +1,266 @@
+import type { AssetResolver } from '../types.js';
+
+import { rewriteAssetRefs } from '../html/rewrite-asset-refs.js';
+
+/**
+ * Tags whose URL attribute targets a page (not a sub-resource). Same-origin
+ * URLs in these attributes are rewritten to the `{{<id>}}` template token so
+ * the downstream scaffold pipeline can resolve the link through its page
+ * registry instead of the migrator hard-coding a file path.
+ *
+ * `<link>` is conditional — `rel` decides whether the href targets a page
+ * (`canonical`, `alternate`, `prev`, `next`) or an asset (`stylesheet`,
+ * `icon`, …). See {@link isPageRef}.
+ */
+const PAGE_REF_TAGS: ReadonlySet<string> = new Set(['a', 'form', 'iframe', 'link']);
+
+/**
+ * `<link rel>` values that name a page reference rather than an asset.
+ * Case-insensitive (the spec normalises tokens).
+ */
+const PAGE_REF_LINK_REL_TOKENS: ReadonlySet<string> = new Set([
+	'canonical',
+	'alternate',
+	'prev',
+	'next',
+]);
+
+/**
+ * URL schemes the resolver refuses to touch — they either point outside the
+ * site (`mailto:`, `tel:`, `sms:`) or are unsafe to interpolate into HTML
+ * (`javascript:`, `data:`, `blob:`, `vbscript:`, `file:`).
+ */
+const SKIPPED_SCHEMES: ReadonlySet<string> = new Set([
+	'mailto:',
+	'tel:',
+	'sms:',
+	'javascript:',
+	'data:',
+	'blob:',
+	'vbscript:',
+	'file:',
+]);
+
+/**
+ * Pre-computed lookup table for `rewritePageRefs`. Built once from a
+ * `pageIds` map via {@link buildPageIdLookup}, then reused across every page
+ * in a migration run — avoids re-parsing every URL on every call. Keys are
+ * normalised (`origin + pathname` with trailing-slash equivalence absorbed),
+ * so an `<a href="/about">` matches a `pageIds` entry stored as
+ * `https://example.com/about/` and vice versa.
+ *
+ * Two maps are exposed so the resolver can prefer an exact `?query` match
+ * before falling back to the pathname-only key — this preserves
+ * disambiguation between URLs that differ only by query string (e.g.
+ * `/list?p=1` vs `/list?p=2`) when both are in `pageIds`.
+ */
+export interface PageIdLookup {
+	/** Keyed by `origin + pathname + search` for exact-query lookups. */
+	readonly byExact: ReadonlyMap<string, number>;
+	/** Keyed by `origin + pathname` (trailing slash absorbed) for fallback lookups. */
+	readonly byPathname: ReadonlyMap<string, number>;
+}
+
+export interface RewritePageRefsOptions {
+	/** The page's HTML (full document or fragment). */
+	readonly html: string;
+	/** The URL of the page itself. Used as the base for resolving relative URLs. */
+	readonly baseUrl: string;
+	/**
+	 * Pre-built page-id lookup table produced by {@link buildPageIdLookup}.
+	 * Build it once at the orchestrator level and pass the same instance to
+	 * every per-page call — building per-page is O(N²) in archive size.
+	 */
+	readonly pageIdLookup: PageIdLookup;
+}
+
+/**
+ * Rewrites in-page URL references using a resolver that:
+ *
+ * 1. Resolves the raw attribute against `baseUrl`. Unparsable / non-http(s)
+ *    schemes (`mailto:`, `javascript:`, `data:`, …) and bare fragments (`#x`)
+ *    are left untouched. Whitespace-padded values are trimmed before classifying.
+ * 2. For URLs whose origin matches the page's, builds a root-relative path
+ *    (`/img/a.png`) so the output is portable across deployment paths.
+ * 3. When the attribute belongs to a page-reference tag (`<a href>`,
+ *    `<form action>`, `<iframe src>`, or `<link href>` with `rel` in
+ *    `canonical`/`alternate`/`prev`/`next`) AND the resolved URL maps to a
+ *    known page, swaps the path for `{{<id>}}` while preserving the query and
+ *    fragment (`{{42}}#team`). Exact `?query` matches are preferred over the
+ *    pathname-only fallback.
+ *
+ * Cross-origin URLs are returned untouched so external links keep working
+ * verbatim.
+ *
+ * Asset references and same-origin page references with no id mapping fall
+ * through to the root-relative form.
+ * @param options
+ * @example
+ * const lookup = buildPageIdLookup(new Map([
+ *   ['https://example.com/about/', 42],
+ * ]));
+ * await rewritePageRefs({
+ *   html: '<a href="/about/">about</a><img src="/img/a.png">',
+ *   baseUrl: 'https://example.com/',
+ *   pageIdLookup: lookup,
+ * });
+ * // → '<a href="{{42}}">about</a><img src="/img/a.png">'
+ */
+export async function rewritePageRefs(options: RewritePageRefsOptions): Promise<string> {
+	const { html, baseUrl, pageIdLookup } = options;
+
+	let basePageOrigin: string;
+	try {
+		basePageOrigin = new URL(baseUrl).origin;
+	} catch {
+		return html;
+	}
+
+	const resolver: AssetResolver = (rawUrl, _attribute, tagName, tagAttrs) => {
+		// Trim before classifying so legacy hand-written HTML with leading
+		// whitespace (e.g. `href=" #section"`) is still recognised as a
+		// bare-fragment anchor and left alone.
+		const trimmed = rawUrl.trim();
+		if (trimmed === '' || trimmed.startsWith('#')) {
+			return null;
+		}
+		let resolved: URL;
+		try {
+			resolved = new URL(trimmed, baseUrl);
+		} catch {
+			return null;
+		}
+		if (SKIPPED_SCHEMES.has(resolved.protocol)) {
+			return null;
+		}
+		if (resolved.origin !== basePageOrigin) {
+			return null;
+		}
+		if (isPageRef(tagName, tagAttrs)) {
+			const id = lookupPageId(resolved, pageIdLookup);
+			if (id !== undefined) {
+				return `{{${id}}}${resolved.search}${resolved.hash}`;
+			}
+		}
+		return `${resolved.pathname}${resolved.search}${resolved.hash}`;
+	};
+
+	return await rewriteAssetRefs(html, resolver);
+}
+
+/**
+ * Builds the pre-keyed lookup tables consumed by {@link rewritePageRefs}.
+ * Run this once per migration (e.g. in `extractPages`) and pass the result to
+ * every per-page invocation — building it inside the per-page hot path is
+ * O(N²) in the archive size and re-derives an invariant value.
+ *
+ * Trailing-slash normalisation: each entry is registered under both the
+ * trailing-slash and trailing-slash-stripped pathname so an `<a href="/about">`
+ * can match a `pageIds` key of `https://example.com/about/` (and vice versa).
+ * When two entries collide on the normalised key, the last write wins — this
+ * mirrors the original Map's semantics and is documented so callers can avoid
+ * intentional collisions.
+ * @param pageIds
+ * @example
+ * const lookup = buildPageIdLookup(new Map([
+ *   ['https://example.com/about/', 10_000],
+ *   ['https://example.com/list?p=1', 5],
+ *   ['https://example.com/list?p=2', 10],
+ * ]));
+ * // lookup.byExact has the `?p=1` / `?p=2` distinction; lookup.byPathname
+ * // has the trailing-slash-absorbed `/about` ↔ `/about/` mappings.
+ */
+export function buildPageIdLookup(pageIds: ReadonlyMap<string, number>): PageIdLookup {
+	const byExact = new Map<string, number>();
+	const byPathname = new Map<string, number>();
+	for (const [url, id] of pageIds) {
+		let parsed: URL;
+		try {
+			parsed = new URL(url);
+		} catch {
+			// assignPageIds already drops unparsable entries; defensive only.
+			continue;
+		}
+		byExact.set(`${parsed.origin}${parsed.pathname}${parsed.search}`, id);
+		registerPathnameKey(byPathname, parsed.origin, parsed.pathname, id);
+	}
+	return { byExact, byPathname };
+}
+
+/**
+ * Stores `id` under both `origin + pathname` and the trailing-slash variant
+ * (added or stripped) so the resolver hits regardless of which form the source
+ * HTML used.
+ * @param target
+ * @param origin
+ * @param pathname
+ * @param id
+ */
+function registerPathnameKey(
+	target: Map<string, number>,
+	origin: string,
+	pathname: string,
+	id: number,
+): void {
+	target.set(`${origin}${pathname}`, id);
+	if (pathname === '/') {
+		return;
+	}
+	const sibling = pathname.endsWith('/') ? pathname.slice(0, -1) : `${pathname}/`;
+	// Only register the sibling key if no other URL has already claimed it —
+	// otherwise an explicit `/about` entry would silently shadow `/about/`.
+	const siblingKey = `${origin}${sibling}`;
+	if (!target.has(siblingKey)) {
+		target.set(siblingKey, id);
+	}
+}
+
+/**
+ * Resolves a same-origin URL to its page id, preferring an exact-query match
+ * before the pathname-only fallback so URLs that differ only by query string
+ * each route to their own id when both are mapped.
+ * @param resolved
+ * @param lookup
+ */
+function lookupPageId(resolved: URL, lookup: PageIdLookup): number | undefined {
+	const exact = lookup.byExact.get(
+		`${resolved.origin}${resolved.pathname}${resolved.search}`,
+	);
+	if (exact !== undefined) {
+		return exact;
+	}
+	return lookup.byPathname.get(`${resolved.origin}${resolved.pathname}`);
+}
+
+/**
+ * Classifies a start tag's URL attribute as page-reference vs. sub-resource.
+ *
+ * `<a>`, `<form>`, and `<iframe>` are unconditional page references. `<link>`
+ * is gated on `rel` — only `canonical` / `alternate` / `prev` / `next` (the
+ * `rel` tokens that name another document) are page references; the dominant
+ * `<link rel="stylesheet"/"icon"/"preload">` cases are assets and fall
+ * through to the root-relative branch.
+ * @param tagName
+ * @param tagAttrs
+ */
+function isPageRef(
+	tagName: string,
+	tagAttrs: readonly { name: string; value: string }[],
+): boolean {
+	if (!PAGE_REF_TAGS.has(tagName)) {
+		return false;
+	}
+	if (tagName !== 'link') {
+		return true;
+	}
+	const rel = tagAttrs.find((attribute) => attribute.name === 'rel')?.value;
+	if (rel === undefined) {
+		return false;
+	}
+	// `rel` is a whitespace-separated token list per the HTML spec; treat it
+	// case-insensitively because authors sometimes write `Canonical`.
+	return rel
+		.toLowerCase()
+		.split(/\s+/)
+		.some((token) => PAGE_REF_LINK_REL_TOKENS.has(token));
+}

--- a/packages/@d-zero/site-migrator/src/types.ts
+++ b/packages/@d-zero/site-migrator/src/types.ts
@@ -35,6 +35,12 @@ export interface InternalResource {
  * mapping layer (so the consumer never sees `description: ""`).
  */
 export interface Frontmatter {
+	/**
+	 * Stable integer id assigned by `assignPageIds`. Emitted at the top of the
+	 * YAML block so the downstream scaffold pipeline can route a `{{<id>}}`
+	 * template token back to this page without parsing the rest of the meta.
+	 */
+	id?: number;
 	title?: string;
 	rawTitle?: string;
 	description?: string;
@@ -71,11 +77,27 @@ export interface TwitterFrontmatter {
 }
 
 /**
+ * One `name`/`value` pair from the current start-tag, surfaced to
+ * {@link AssetResolver} so resolvers can branch on other attributes (e.g. gate
+ * `<link href>` on the `rel` attribute).
+ */
+export interface AssetResolverTagAttribute {
+	readonly name: string;
+	readonly value: string;
+}
+
+/**
  * Resolver callback used by `rewriteAssetRefs`. Return a replacement URL or
  * `null` to leave the attribute value as-is.
+ *
+ * `tagAttrs` is the start-tag's full attribute list (the rewriter forwards
+ * parse5's tokens unchanged) so a resolver can read sibling attributes — e.g.
+ * to gate `<link>` href rewriting on the `rel` attribute. Treat it as
+ * read-only; mutations are not surfaced to the rewriter.
  */
 export type AssetResolver = (
 	url: string,
 	attribute: string,
 	tagName: string,
+	tagAttrs: readonly AssetResolverTagAttribute[],
 ) => string | null;


### PR DESCRIPTION
## Summary

- `extractPages` で全ページの URL に決定論的な整数 id を割り当て、`---\nid: <number>\n---\n` を先頭に prepend する。採番は後段 scaffold パイプラインが期待する方式（root section: 5, 10, 15…/ N 番目のサブディレクトリセクション: N×10000+step5）で、`@d-zero/shared/sort/path` の `pathComparator` と `@d-zero/shared/sort/alphabetical` の `alphabeticalComparator` で安定化済み。1 セクションあたり 2000 ページを超える場合は黙ってエイリアスせず明示的に throw。
- `rewritePageRefs` を新設し、本文中の同一オリジン参照を後段 scaffold パイプライン向けに書き換える。
  - `<a href>` / `<form action>` / `<iframe src>` / `<link rel=canonical|alternate|prev|next href>` → `{{<id>}}?q=foo#frag` テンプレート。
  - その他のアセット属性（img/script/source/embed/video/audio/track/srcset/`<link rel=stylesheet|icon>` 等）→ root-relative path。
  - 外部オリジン・`mailto:` / `tel:` / `sms:` / `javascript:` / `data:` / `blob:` / `vbscript:` / `file:`・`#fragment` 単独（先頭空白付きも含む）は触らない。
- ルックアップは `buildPageIdLookup` で 1 回だけ構築（per-page 構築だと O(N²)）。trailing-slash drift を吸収しつつ exact `?query` 一致を pathname-only fallback より優先するので、`/list?p=1` と `/list?p=2` 双方が `pageIds` にあれば各々の id に解決される。
- `rewritePageRefs` / `getFrontmatter` の失敗は fail-soft。HTML 本文は書き出し、`onResult` の outcome に `rewriteError` / `metaError` を載せて警告、`MigrateReport` の `pagesRewriteFailed` / `pagesMetaFailed` で集計。CLI は stderr に warn を 1 行追加するだけ。
- `AssetResolver` に 4 番目の引数 `tagAttrs` を追加。`<link href>` を `rel` で振り分けるために必要。

## Test plan

- [x] `yarn test`（127 件パス）
- [x] `yarn lint`（cspell / eslint / prettier / textlint 全 OK）
- [x] `yarn build`
- [x] CI 全グリーン