### PR TITLE
feat(site-migrator): resolve page layout via anatomist JSONL or live analysis

### DIFF
--- a/packages/@d-zero/site-migrator/package.json
+++ b/packages/@d-zero/site-migrator/package.json
@@ -32,13 +32,15 @@
 		"dist"
 	],
 	"dependencies": {
+		"@d-zero/anatomist": "0.2.0",
 		"@d-zero/dealer": "1.10.1",
 		"@d-zero/shared": "0.22.2",
 		"@nitpicker/crawler": "0.11.0",
 		"@nitpicker/query": "0.11.0",
 		"js-yaml": "4.3.0",
 		"parse5": "8.0.1",
-		"parse5-html-rewriting-stream": "8.0.1"
+		"parse5-html-rewriting-stream": "8.0.1",
+		"puppeteer": "25.3.0"
 	},
 	"devDependencies": {
 		"@types/js-yaml": "4.0.9",

--- a/packages/@d-zero/site-migrator/src/page-extractor/resolve-page-layout.spec.ts
+++ b/packages/@d-zero/site-migrator/src/page-extractor/resolve-page-layout.spec.ts
@@ -1,0 +1,291 @@
+import type { ResolvePageLayoutResult } from './resolve-page-layout.js';
+import type { LayoutAnalysisResult } from '@d-zero/anatomist/types';
+import type { Browser } from 'puppeteer';
+
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+vi.mock('puppeteer', () => ({
+	launch: vi.fn(),
+}));
+vi.mock('@d-zero/anatomist', () => ({
+	analyzePageLayout: vi.fn(),
+}));
+
+const { launch } = await import('puppeteer');
+const { analyzePageLayout } = await import('@d-zero/anatomist');
+const { parseLayoutJsonl, resolvePageLayouts } = await import('./resolve-page-layout.js');
+
+const launchMock = vi.mocked(launch);
+const analyzePageLayoutMock = vi.mocked(analyzePageLayout);
+
+const sampleResult = (
+	url: string,
+	overrides: Partial<LayoutAnalysisResult> = {},
+): LayoutAnalysisResult => ({
+	url,
+	viewport: { name: 'pc', width: 1280 },
+	mainSelector: 'main',
+	root: null,
+	...overrides,
+});
+
+/**
+ * Minimal `Browser` double: only `newPage`/`close` are exercised by
+ * `resolvePageLayouts`. Both resolve to match the real Puppeteer API's
+ * `Promise`-returning contract.
+ */
+function fakeBrowser() {
+	return {
+		newPage: vi.fn(() => ({ close: vi.fn(() => Promise.resolve()) })),
+		close: vi.fn(() => Promise.resolve()),
+	};
+}
+
+describe('resolvePageLayouts', () => {
+	let tmpDir = '';
+
+	beforeEach(async () => {
+		tmpDir = await mkdtemp(path.join(tmpdir(), 'site-migrator-layout-'));
+		launchMock.mockReset();
+		analyzePageLayoutMock.mockReset();
+	});
+
+	afterEach(async () => {
+		await rm(tmpDir, { recursive: true, force: true });
+	});
+
+	test('resolves all URLs live when layoutJsonPath is omitted', async () => {
+		const browser = fakeBrowser();
+		launchMock.mockResolvedValueOnce(browser as unknown as Browser);
+		const liveResult = sampleResult('https://example.com/a');
+		analyzePageLayoutMock.mockResolvedValueOnce([liveResult]);
+
+		const results: ResolvePageLayoutResult[] = [];
+		await resolvePageLayouts({
+			items: [{ url: 'https://example.com/a' }],
+			onResult: (event) => results.push(event),
+		});
+
+		expect(results).toEqual([
+			{ url: 'https://example.com/a', outcome: 'resolved-live', results: [liveResult] },
+		]);
+		expect(browser.newPage).toHaveBeenCalledTimes(1);
+		expect(browser.close).toHaveBeenCalledTimes(1);
+	});
+
+	test('uses a JSON hit as-is (including root:null) and live-analyzes only the rest', async () => {
+		const hitResult = sampleResult('https://example.com/hit');
+		const jsonlPath = path.join(tmpDir, 'layout.jsonl');
+		await writeFile(jsonlPath, `${JSON.stringify(hitResult)}\n`, 'utf8');
+
+		const browser = fakeBrowser();
+		launchMock.mockResolvedValueOnce(browser as unknown as Browser);
+		const liveResult = sampleResult('https://example.com/miss');
+		analyzePageLayoutMock.mockResolvedValueOnce([liveResult]);
+
+		const results: ResolvePageLayoutResult[] = [];
+		await resolvePageLayouts({
+			items: [{ url: 'https://example.com/hit' }, { url: 'https://example.com/miss' }],
+			layoutJsonPath: jsonlPath,
+			onResult: (event) => results.push(event),
+		});
+
+		expect(results).toContainEqual({
+			url: 'https://example.com/hit',
+			outcome: 'resolved-from-json',
+			results: [hitResult],
+		});
+		expect(results).toContainEqual({
+			url: 'https://example.com/miss',
+			outcome: 'resolved-live',
+			results: [liveResult],
+		});
+		// Only the JSON-miss URL should have opened a page.
+		expect(browser.newPage).toHaveBeenCalledTimes(1);
+	});
+
+	test('launches the browser only once when multiple URLs need live analysis', async () => {
+		const browser = fakeBrowser();
+		launchMock.mockResolvedValueOnce(browser as unknown as Browser);
+		analyzePageLayoutMock.mockResolvedValue([sampleResult('https://example.com/a')]);
+
+		await resolvePageLayouts({
+			items: [{ url: 'https://example.com/a' }, { url: 'https://example.com/b' }],
+		});
+
+		expect(launchMock).toHaveBeenCalledTimes(1);
+		expect(browser.newPage).toHaveBeenCalledTimes(2);
+	});
+
+	test('does not launch a browser when every URL is covered by layoutJsonPath', async () => {
+		const hitResult = sampleResult('https://example.com/hit');
+		const jsonlPath = path.join(tmpDir, 'layout.jsonl');
+		await writeFile(jsonlPath, `${JSON.stringify(hitResult)}\n`, 'utf8');
+
+		const results: ResolvePageLayoutResult[] = [];
+		await resolvePageLayouts({
+			items: [{ url: 'https://example.com/hit' }],
+			layoutJsonPath: jsonlPath,
+			onResult: (event) => results.push(event),
+		});
+
+		expect(results).toEqual([
+			{
+				url: 'https://example.com/hit',
+				outcome: 'resolved-from-json',
+				results: [hitResult],
+			},
+		]);
+		expect(launchMock).not.toHaveBeenCalled();
+	});
+
+	test('reports outcome=missing with a classified kind when live analysis throws', async () => {
+		const browser = fakeBrowser();
+		launchMock.mockResolvedValueOnce(browser as unknown as Browser);
+		analyzePageLayoutMock.mockRejectedValueOnce(
+			new Error('getaddrinfo ENOTFOUND example.invalid'),
+		);
+
+		const results: ResolvePageLayoutResult[] = [];
+		await resolvePageLayouts({
+			items: [{ url: 'https://example.invalid/' }],
+			onResult: (event) => results.push(event),
+		});
+
+		expect(results).toHaveLength(1);
+		const [result] = results;
+		expect(result.outcome).toBe('missing');
+		if (result.outcome === 'missing') {
+			expect(result.kind).toBe('dns');
+			expect(result.error.message).toContain('ENOTFOUND');
+		}
+	});
+
+	test('reports outcome=missing (without hanging) when browser.newPage() itself throws', async () => {
+		const browser = fakeBrowser();
+		browser.newPage.mockImplementationOnce(() => {
+			throw new Error('Target.createTarget failed');
+		});
+		launchMock.mockResolvedValueOnce(browser as unknown as Browser);
+
+		const results: ResolvePageLayoutResult[] = [];
+		await resolvePageLayouts({
+			items: [{ url: 'https://example.com/a' }],
+			onResult: (event) => results.push(event),
+		});
+
+		expect(results).toHaveLength(1);
+		expect(results[0]?.outcome).toBe('missing');
+	});
+
+	test('does not hang and still reports the result when page.close() rejects during cleanup', async () => {
+		const page = {
+			close: vi.fn().mockRejectedValueOnce(new Error('Protocol error: Target closed')),
+		};
+		const browser = {
+			newPage: vi.fn(() => page),
+			close: vi.fn(),
+		};
+		launchMock.mockResolvedValueOnce(browser as unknown as Browser);
+		const liveResult = sampleResult('https://example.com/a');
+		analyzePageLayoutMock.mockResolvedValueOnce([liveResult]);
+
+		const results: ResolvePageLayoutResult[] = [];
+		await resolvePageLayouts({
+			items: [{ url: 'https://example.com/a' }],
+			onResult: (event) => results.push(event),
+		});
+
+		expect(results).toEqual([
+			{ url: 'https://example.com/a', outcome: 'resolved-live', results: [liveResult] },
+		]);
+	});
+
+	test('rejects without launching a browser when layoutJsonPath contains an invalid line', async () => {
+		const jsonlPath = path.join(tmpDir, 'bad.jsonl');
+		await writeFile(jsonlPath, 'not json\n', 'utf8');
+
+		await expect(
+			resolvePageLayouts({
+				items: [{ url: 'https://example.com/a' }],
+				layoutJsonPath: jsonlPath,
+			}),
+		).rejects.toThrow(/1行目/);
+		expect(launchMock).not.toHaveBeenCalled();
+	});
+
+	test('returns immediately without launching a browser when items is empty', async () => {
+		await resolvePageLayouts({ items: [] });
+		expect(launchMock).not.toHaveBeenCalled();
+	});
+
+	test('returns immediately without launching a browser when the signal is already aborted', async () => {
+		const controller = new AbortController();
+		controller.abort();
+
+		await resolvePageLayouts({
+			items: [{ url: 'https://example.com/a' }],
+			signal: controller.signal,
+		});
+
+		expect(launchMock).not.toHaveBeenCalled();
+	});
+});
+
+describe('parseLayoutJsonl', () => {
+	test('throws with a 1-based line number on invalid JSON', () => {
+		expect(() => parseLayoutJsonl('not json')).toThrow(/1行目/);
+	});
+
+	test.each([
+		['not an object', '"just a string"'],
+		['missing url', JSON.stringify({ url: 'https://example.com/' })],
+		[
+			'viewport.name not a string',
+			JSON.stringify({
+				...sampleResult('https://example.com/a'),
+				viewport: { name: 1, width: 1280 },
+			}),
+		],
+		[
+			'viewport.width not a number',
+			JSON.stringify({
+				...sampleResult('https://example.com/a'),
+				viewport: { name: 'pc', width: '1280' },
+			}),
+		],
+		[
+			'mainSelector neither a string nor null',
+			JSON.stringify({ ...sampleResult('https://example.com/a'), mainSelector: 123 }),
+		],
+		[
+			'root field missing entirely',
+			JSON.stringify({
+				url: 'https://example.com/a',
+				viewport: { name: 'pc', width: 1280 },
+				mainSelector: 'main',
+			}),
+		],
+	])('throws when the shape does not match LayoutAnalysisResult (%s)', (_label, line) => {
+		expect(() => parseLayoutJsonl(line)).toThrow(/1行目/);
+	});
+
+	test('skips blank lines', () => {
+		const result = sampleResult('https://example.com/a');
+		const map = parseLayoutJsonl(`\n${JSON.stringify(result)}\n\n`);
+		expect(map.get('https://example.com/a')).toEqual([result]);
+	});
+
+	test('accumulates multiple viewport entries for the same URL, in file order', () => {
+		const pc = sampleResult('https://example.com/a');
+		const mobile = sampleResult('https://example.com/a', {
+			viewport: { name: 'mobile', width: 375 },
+		});
+		const map = parseLayoutJsonl(`${JSON.stringify(pc)}\n${JSON.stringify(mobile)}\n`);
+		expect(map.get('https://example.com/a')).toEqual([pc, mobile]);
+	});
+});

--- a/packages/@d-zero/site-migrator/src/page-extractor/resolve-page-layout.ts
+++ b/packages/@d-zero/site-migrator/src/page-extractor/resolve-page-layout.ts
@@ -1,0 +1,210 @@
+import type { LayoutAnalysisResult } from '@d-zero/anatomist/types';
+import type { ErrorKind } from '@nitpicker/query';
+import type { Browser } from 'puppeteer';
+
+import { readFile } from 'node:fs/promises';
+
+import { analyzePageLayout } from '@d-zero/anatomist';
+import { deal } from '@d-zero/dealer';
+import { classifyErrorKind } from '@nitpicker/query';
+import { launch } from 'puppeteer';
+
+/**
+ * Single page to resolve a layout for. Wrapped as an object so
+ * `@d-zero/dealer` (which requires `T extends WeakKey`) can track progress
+ * against it (same reason as `ExtractPageItem` in `extract-pages.ts`).
+ */
+export interface ResolvePageLayoutItem {
+	url: string;
+}
+
+export type ResolvePageLayoutResult =
+	| { url: string; outcome: 'resolved-from-json'; results: LayoutAnalysisResult[] }
+	| { url: string; outcome: 'resolved-live'; results: LayoutAnalysisResult[] }
+	| { url: string; outcome: 'missing'; error: Error; kind: ErrorKind };
+
+export interface ResolvePageLayoutsOptions {
+	items: readonly ResolvePageLayoutItem[];
+	/**
+	 * Path to a pre-generated anatomist JSONL file. URLs present in it are
+	 * used as-is; URLs absent from it (or when this option is omitted
+	 * entirely) fall back to live analysis.
+	 */
+	layoutJsonPath?: string;
+	/**
+	 * Maximum concurrent live analyses. Intended to share the caller's
+	 * `--extract-limit` value rather than introduce a separate flag.
+	 * Defaults to 10, matching {@link import('./extract-pages.js').extractPages}.
+	 */
+	limit?: number;
+	onResult?: (event: ResolvePageLayoutResult) => void;
+	signal?: AbortSignal;
+}
+
+/**
+ * Narrows `unknown` to `LayoutAnalysisResult` by checking the shape of the
+ * fields this module reads (`url`, `viewport.name`/`.width`, `mainSelector`,
+ * presence of `root`). Does not recurse into `root`'s `LayoutBlock` tree —
+ * anatomist owns that shape, and re-validating it here would just duplicate
+ * anatomist's own type without adding safety.
+ * @param value
+ */
+function isLayoutAnalysisResult(value: unknown): value is LayoutAnalysisResult {
+	if (typeof value !== 'object' || value === null) {
+		return false;
+	}
+	const candidate = value as Record<string, unknown>;
+	if (typeof candidate.url !== 'string') {
+		return false;
+	}
+	if (typeof candidate.viewport !== 'object' || candidate.viewport === null) {
+		return false;
+	}
+	const viewport = candidate.viewport as Record<string, unknown>;
+	if (typeof viewport.name !== 'string' || typeof viewport.width !== 'number') {
+		return false;
+	}
+	if (candidate.mainSelector !== null && typeof candidate.mainSelector !== 'string') {
+		return false;
+	}
+	// `root` is `LayoutBlock | null`; only check it's present as one of those
+	// two shapes (`typeof null === 'object'` covers both in one check).
+	return typeof candidate.root === 'object';
+}
+
+/**
+ * Parses anatomist's JSONL layout format (one `LayoutAnalysisResult` per
+ * line, one line per URL × viewport) into a map keyed by URL. Multiple
+ * lines for the same URL (one per viewport) accumulate into that URL's
+ * array, in file order.
+ *
+ * Fails fast: `--layout-json` files are machine-generated input, so a
+ * malformed line (invalid JSON or wrong shape) throws immediately with a
+ * 1-based line number rather than being skipped — it signals a
+ * misconfiguration (wrong file, stale format) rather than a per-page
+ * condition to recover from.
+ * @param content
+ */
+export function parseLayoutJsonl(content: string): Map<string, LayoutAnalysisResult[]> {
+	const map = new Map<string, LayoutAnalysisResult[]>();
+	const lines = content.split('\n');
+	for (const [index, rawLine] of lines.entries()) {
+		const line = rawLine.trim();
+		if (line === '') {
+			continue;
+		}
+		let parsed: unknown;
+		try {
+			parsed = JSON.parse(line);
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error);
+			throw new Error(`${index + 1}行目: JSONとして解析できません (${message})`);
+		}
+		if (!isLayoutAnalysisResult(parsed)) {
+			throw new Error(`${index + 1}行目: LayoutAnalysisResultの形状が不正です`);
+		}
+		const bucket = map.get(parsed.url);
+		if (bucket === undefined) {
+			map.set(parsed.url, [parsed]);
+		} else {
+			bucket.push(parsed);
+		}
+	}
+	return map;
+}
+
+/**
+ * Resolves each page's layout analysis, preferring a pre-generated anatomist
+ * JSONL file (`layoutJsonPath`) and falling back to a live Puppeteer-driven
+ * `analyzePageLayout` call for any URL absent from it.
+ *
+ * A JSONL hit is used as-is even when its `root` is `null` (anatomist ran
+ * but found no main-content element) — that's itself a valid analysis
+ * outcome, and re-running it live would likely reproduce the same result
+ * while adding an unnecessary hit against the live site. Interpreting
+ * `root: null` is left to the caller (the BlockData conversion step).
+ *
+ * Live failures — including a `browser.newPage()`/`page.close()` failure,
+ * not just `analyzePageLayout` itself — are classified via
+ * `@nitpicker/query`'s `classifyErrorKind` and reported as `missing` through
+ * `onResult` rather than thrown. `@d-zero/dealer`'s `deal()` requires every
+ * worker to settle without rejecting (see its `Dealer#deal()` contract:
+ * a rejected worker never signals completion, hanging the whole run) — so
+ * the entire per-item body, not just the `analyzePageLayout` call, is inside
+ * the try/catch. Mirrors
+ * {@link import('./extract-pages.js').extractPages}'s fail-soft design.
+ *
+ * Reading and parsing `layoutJsonPath` is fail-fast by contrast (see
+ * {@link parseLayoutJsonl}): it's machine-generated input, and a parse
+ * failure should stop the whole run rather than be reported per-page.
+ *
+ * The browser is launched lazily, on the first URL that actually needs live
+ * analysis — a run where every URL is covered by `layoutJsonPath` never
+ * pays for a browser at all.
+ * @param options
+ */
+export async function resolvePageLayouts(
+	options: ResolvePageLayoutsOptions,
+): Promise<void> {
+	const { items, layoutJsonPath, limit = 10, onResult, signal } = options;
+	if (items.length === 0 || signal?.aborted) {
+		// Short-circuit before launching a browser for work that will never run.
+		return;
+	}
+
+	const jsonMap =
+		layoutJsonPath === undefined
+			? new Map<string, LayoutAnalysisResult[]>()
+			: parseLayoutJsonl(await readFile(layoutJsonPath, 'utf8'));
+
+	// Lazily launched, and launched at most once: concurrent workers all read
+	// the same cached promise instead of racing separate `launch()` calls.
+	let browserPromise: Promise<Browser> | undefined;
+	const getBrowser = (): Promise<Browser> => {
+		browserPromise ??= launch({ headless: true });
+		return browserPromise;
+	};
+
+	try {
+		await deal(
+			items,
+			(item) => async () => {
+				const hit = jsonMap.get(item.url);
+				if (hit !== undefined) {
+					onResult?.({ url: item.url, outcome: 'resolved-from-json', results: hit });
+					return;
+				}
+				let page: Awaited<ReturnType<Browser['newPage']>> | undefined;
+				try {
+					const browser = await getBrowser();
+					page = await browser.newPage();
+					const results = await analyzePageLayout(page, item.url);
+					onResult?.({ url: item.url, outcome: 'resolved-live', results });
+				} catch (error) {
+					const err = error instanceof Error ? error : new Error(String(error));
+					onResult?.({
+						url: item.url,
+						outcome: 'missing',
+						error: err,
+						kind: classifyErrorKind(err.message),
+					});
+				} finally {
+					// Best-effort cleanup: a close failure (sync throw or
+					// rejection) must not reject this worker (see the dealer
+					// contract note above).
+					try {
+						await page?.close();
+					} catch {
+						/* ignore */
+					}
+				}
+			},
+			{ limit, signal },
+		);
+	} finally {
+		if (browserPromise !== undefined) {
+			const browser = await browserPromise;
+			await browser.close();
+		}
+	}
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1244,6 +1244,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@d-zero/anatomist@npm:0.2.0":
+  version: 0.2.0
+  resolution: "@d-zero/anatomist@npm:0.2.0"
+  dependencies:
+    "@d-zero/beholder": "npm:4.2.0"
+    "@d-zero/dealer": "npm:1.10.2"
+    "@d-zero/puppeteer-page-scan": "npm:4.6.6"
+    "@d-zero/shared": "npm:0.22.3"
+    puppeteer: "npm:25.3.0"
+  bin:
+    anatomist: dist/cli.js
+  checksum: 10c0/e868dd20dc0bfc51dfa842d50f60e53545eb1c86da1c26f9f331f1b0521b246e324dbbf2f9a65f8bd67eb602f6eaaa49b129f53a4d41425f56e679a48dea6999
+  languageName: node
+  linkType: hard
+
 "@d-zero/beholder@npm:3.1.1":
   version: 3.1.1
   resolution: "@d-zero/beholder@npm:3.1.1"
@@ -1254,6 +1269,19 @@ __metadata:
     puppeteer: "npm:24.37.5"
     simple-wappalyzer: "npm:1.1.99"
   checksum: 10c0/ce7787e10efd8ed6e940dedefbb6bb1b1c5847cc12dc4eace3c2add7753007ac7ae1c31d5ff5ab17629fbdbc565d00665f551eb01ac45510de5684d1635ce4d6
+  languageName: node
+  linkType: hard
+
+"@d-zero/beholder@npm:4.2.0":
+  version: 4.2.0
+  resolution: "@d-zero/beholder@npm:4.2.0"
+  dependencies:
+    "@d-zero/puppeteer-page-scan": "npm:4.6.6"
+    "@d-zero/shared": "npm:0.22.3"
+    debug: "npm:4.4.3"
+    puppeteer: "npm:25.3.0"
+    simple-wappalyzer: "npm:1.1.100"
+  checksum: 10c0/474a204ba63eec82d0c6d1bcff0ec8304b973d7b1b008ed8324a2cbe089a9147bf44c75cb406d36762867e481bc181b046f88b4c35f743e9190f57d9e9869b53
   languageName: node
   linkType: hard
 
@@ -1346,6 +1374,16 @@ __metadata:
     "@d-zero/shared": "npm:0.22.2"
     ansi-colors: "npm:4.1.3"
   checksum: 10c0/7ea6e587880a7483a330119ecae643118d5d90b1e8586658ab51cf8c80c8c5f8b5ee627f13deac34313ade6481f984d1df8601b023b7bb845239e5c5814804ef
+  languageName: node
+  linkType: hard
+
+"@d-zero/dealer@npm:1.10.2":
+  version: 1.10.2
+  resolution: "@d-zero/dealer@npm:1.10.2"
+  dependencies:
+    "@d-zero/shared": "npm:0.22.3"
+    ansi-colors: "npm:4.1.3"
+  checksum: 10c0/12bee8088d31ccb123d294a81fcf4f451c71a347b29e2b1e5d9df527872e36ae94377bf537662088ce0a7a425df06184e54fe8d213841ccd5a7a1c4d49797c90
   languageName: node
   linkType: hard
 
@@ -1483,6 +1521,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@d-zero/puppeteer-general-actions@npm:1.2.6":
+  version: 1.2.6
+  resolution: "@d-zero/puppeteer-general-actions@npm:1.2.6"
+  dependencies:
+    ansi-colors: "npm:4.1.3"
+  checksum: 10c0/b7c230c100eee73a80a77fa479395b88c2ac3357eedbfa03ae616c352ebacb41c529942f1d54eb47a6f1651d2eb3216bbcf60d8b0c728c9c676b3fe81c48c878
+  languageName: node
+  linkType: hard
+
 "@d-zero/puppeteer-page-scan@npm:4.6.0":
   version: 4.6.0
   resolution: "@d-zero/puppeteer-page-scan@npm:4.6.0"
@@ -1496,6 +1543,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@d-zero/puppeteer-page-scan@npm:4.6.6":
+  version: 4.6.6
+  resolution: "@d-zero/puppeteer-page-scan@npm:4.6.6"
+  dependencies:
+    "@d-zero/puppeteer-general-actions": "npm:1.2.6"
+    "@d-zero/puppeteer-scroll": "npm:4.0.9"
+    "@d-zero/shared": "npm:0.22.3"
+  peerDependencies:
+    puppeteer: 25.2.1
+  checksum: 10c0/0257fe21786a55a2c59e3961c8551819a166d951b4a41f728cc37ea5e22093556c58e22ea97ad34a16235e6707744a73d1c50af5751d8bd2823ee17503054ef2
+  languageName: node
+  linkType: hard
+
 "@d-zero/puppeteer-scroll@npm:4.0.3":
   version: 4.0.3
   resolution: "@d-zero/puppeteer-scroll@npm:4.0.3"
@@ -1504,6 +1564,17 @@ __metadata:
   peerDependencies:
     puppeteer: 24.37.5
   checksum: 10c0/07234339cf3466a05abd0bd754864f1625291f263784685722ae52ce227838ce21d4e6ee3cbcdb21bb8c03a5ea094feed36d2c74ea5d4b321adc30d5ab02ed1d
+  languageName: node
+  linkType: hard
+
+"@d-zero/puppeteer-scroll@npm:4.0.9":
+  version: 4.0.9
+  resolution: "@d-zero/puppeteer-scroll@npm:4.0.9"
+  dependencies:
+    "@d-zero/shared": "npm:0.22.3"
+  peerDependencies:
+    puppeteer: 25.2.1
+  checksum: 10c0/5a6401b15368b233cc83cc66fcc7075f00db2dcba3e38560c8422408e067ea5c3fe569118ba90fd5bb6cdbcfaa327e6368654ab5372f0d6f33a27f186b17a80a
   languageName: node
   linkType: hard
 
@@ -1628,10 +1699,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@d-zero/shared@npm:0.22.3":
+  version: 0.22.3
+  resolution: "@d-zero/shared@npm:0.22.3"
+  dependencies:
+    "@holiday-jp/holiday_jp": "npm:2.5.1"
+    await-event-emitter: "npm:2.0.2"
+    dayjs: "npm:1.11.21"
+    escape-string-regexp: "npm:5.0.0"
+    front-matter: "npm:4.0.2"
+    micromatch: "npm:4.0.8"
+    sanitize-filename: "npm:1.6.4"
+  checksum: 10c0/2458def65fafe5e0ae652132ef0cafc862974245779d88808ec1c35a5dba4ec2e5a82a32c6d631241612ded2daae5207602593161d68b521af824b0f7dd91aaa
+  languageName: node
+  linkType: hard
+
 "@d-zero/site-migrator@workspace:packages/@d-zero/site-migrator":
   version: 0.0.0-use.local
   resolution: "@d-zero/site-migrator@workspace:packages/@d-zero/site-migrator"
   dependencies:
+    "@d-zero/anatomist": "npm:0.2.0"
     "@d-zero/dealer": "npm:1.10.1"
     "@d-zero/shared": "npm:0.22.2"
     "@nitpicker/crawler": "npm:0.11.0"
@@ -1641,6 +1728,7 @@ __metadata:
     js-yaml: "npm:4.3.0"
     parse5: "npm:8.0.1"
     parse5-html-rewriting-stream: "npm:8.0.1"
+    puppeteer: "npm:25.3.0"
   bin:
     dz-migrate: ./dist/cli.js
   languageName: unknown
@@ -4211,6 +4299,26 @@ __metadata:
   bin:
     browsers: lib/cjs/main-cli.js
   checksum: 10c0/90c761200da538234100a7f7cd0677c60cfcfbf710445fb2d82ece34bf3b5a015958919d110d7041a0680fe1d690e3e7737594fe2efd6a7dac8681ef646ecc3e
+  languageName: node
+  linkType: hard
+
+"@puppeteer/browsers@npm:3.0.6":
+  version: 3.0.6
+  resolution: "@puppeteer/browsers@npm:3.0.6"
+  dependencies:
+    modern-tar: "npm:^0.7.6"
+    yargs: "npm:^18.0.0"
+  peerDependencies:
+    proxy-agent: ">=8.0.1"
+    yauzl: ^2.10.0 || ^3.4.0
+  peerDependenciesMeta:
+    proxy-agent:
+      optional: true
+    yauzl:
+      optional: true
+  bin:
+    browsers: lib/main-cli.js
+  checksum: 10c0/145c9136b6a4a2de0a1a6413ab92eb791384a8d103dea253a487eacaaabc66927205dbe843f899dfb961fb0fddc164e17ad6fbad83bc40ff39513a0a0b51172a
   languageName: node
   linkType: hard
 
@@ -7207,6 +7315,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"chromium-bidi@npm:16.0.1":
+  version: 16.0.1
+  resolution: "chromium-bidi@npm:16.0.1"
+  dependencies:
+    mitt: "npm:^3.0.1"
+    zod: "npm:^3.24.1"
+  peerDependencies:
+    devtools-protocol: "*"
+  checksum: 10c0/cfd67f14c4e1f2d2f5e2a3661300c7f487f964445314956eb4005d46c056814fa9d1dcb854a2c6c3537de37d7c134a3889703901f948524d994ae8b76cf7e9bc
+  languageName: node
+  linkType: hard
+
 "chrono-node@npm:2.8.4":
   version: 2.8.4
   resolution: "chrono-node@npm:2.8.4"
@@ -7387,6 +7507,17 @@ __metadata:
     strip-ansi: "npm:^6.0.1"
     wrap-ansi: "npm:^7.0.0"
   checksum: 10c0/4bda0f09c340cbb6dfdc1ed508b3ca080f12992c18d68c6be4d9cf51756033d5266e61ec57529e610dacbf4da1c634423b0c1b11037709cc6b09045cbd815df5
+  languageName: node
+  linkType: hard
+
+"cliui@npm:^9.0.1":
+  version: 9.0.1
+  resolution: "cliui@npm:9.0.1"
+  dependencies:
+    string-width: "npm:^7.2.0"
+    strip-ansi: "npm:^7.1.0"
+    wrap-ansi: "npm:^9.0.0"
+  checksum: 10c0/13441832e9efe7c7a76bd2b8e683555c478d461a9f249dc5db9b17fe8d4b47fa9277b503914b90bd00e4a151abb6b9b02b2288972ffe2e5e3ca40bcb1c2330d3
   languageName: node
   linkType: hard
 
@@ -8650,6 +8781,13 @@ __metadata:
   version: 0.0.1566079
   resolution: "devtools-protocol@npm:0.0.1566079"
   checksum: 10c0/a220a0a408df35efe118249d822d7b79874a1374b4eba0d59473a3d98623c7d0159f9833541086eeaa0da18f92e450b1c099cdbc6525277e804e2571cd530b8a
+  languageName: node
+  linkType: hard
+
+"devtools-protocol@npm:0.0.1638949":
+  version: 0.0.1638949
+  resolution: "devtools-protocol@npm:0.0.1638949"
+  checksum: 10c0/68aab193628a6a9c06487c1d68f39a106f50e3f83784a8767ee8d703a1f1fde4f055a59f239bda3a0bb76941fecf1da3122d3b66b81b5ea36dc0532223479c79
   languageName: node
   linkType: hard
 
@@ -13980,6 +14118,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"modern-tar@npm:^0.7.6":
+  version: 0.7.7
+  resolution: "modern-tar@npm:0.7.7"
+  checksum: 10c0/5363f46514e2be5dc76726cd252bf8adde159268358bc21980b63d581d1072046bba51207455989ddcd3c794c42fc809c81737a15cb970a880868ad6e40299fb
+  languageName: node
+  linkType: hard
+
 "modify-values@npm:^1.0.1":
   version: 1.0.1
   resolution: "modify-values@npm:1.0.1"
@@ -16612,6 +16757,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"puppeteer-core@npm:25.3.0":
+  version: 25.3.0
+  resolution: "puppeteer-core@npm:25.3.0"
+  dependencies:
+    "@puppeteer/browsers": "npm:3.0.6"
+    chromium-bidi: "npm:16.0.1"
+    devtools-protocol: "npm:0.0.1638949"
+    typed-query-selector: "npm:^2.12.2"
+    webdriver-bidi-protocol: "npm:0.4.2"
+    ws: "npm:^8.21.0"
+  checksum: 10c0/95453c7553a1795c2cf99991783235c1ad6fed5f2601e5910ab379f4283e8a5de93f6da9735c1bf8bfa3d77ee2b333fd11537174fd524bb6877ed1797ae92e30
+  languageName: node
+  linkType: hard
+
 "puppeteer@npm:24.37.5":
   version: 24.37.5
   resolution: "puppeteer@npm:24.37.5"
@@ -16625,6 +16784,22 @@ __metadata:
   bin:
     puppeteer: lib/cjs/puppeteer/node/cli.js
   checksum: 10c0/28f1e72ca44ba5df9a8913f987aabb929dce004f98f7a245ce9ddb33ce31bd42e385a63a5b6b9d30eefbd7b2c2bf6e89c9704771182b3fcee7dd106bf911e18c
+  languageName: node
+  linkType: hard
+
+"puppeteer@npm:25.3.0":
+  version: 25.3.0
+  resolution: "puppeteer@npm:25.3.0"
+  dependencies:
+    "@puppeteer/browsers": "npm:3.0.6"
+    chromium-bidi: "npm:16.0.1"
+    devtools-protocol: "npm:0.0.1638949"
+    lilconfig: "npm:^3.1.3"
+    puppeteer-core: "npm:25.3.0"
+    typed-query-selector: "npm:^2.12.2"
+  bin:
+    puppeteer: lib/puppeteer/node/cli.js
+  checksum: 10c0/0c4a52dad12f30f8d7f90f2f8cde3cff686b0d496d482cedd5206a9fb40af38b958ab33f4ff4e086af0937a5af011ba4351bd556cc07924af208edbcdaf96fc2
   languageName: node
   linkType: hard
 
@@ -17717,6 +17892,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"simple-wappalyzer@npm:1.1.100":
+  version: 1.1.100
+  resolution: "simple-wappalyzer@npm:1.1.100"
+  dependencies:
+    got: "npm:~11.8.6"
+    happy-dom: "npm:~20.10.0"
+    lodash: "npm:~4.18.1"
+    tough-cookie: "npm:~6.0.0"
+    wappalyzer-core: "npm:6"
+    write-json-file: "npm:~4.3.0"
+  checksum: 10c0/d5449ab44bbad144a4856113c42515aebb3a8534997b3e1c77669f48d3ac40a264bfa37392c8d168c6fff878398ef572c7d29acaadad973ab212f66aff02cf5b
+  languageName: node
+  linkType: hard
+
 "simple-wappalyzer@npm:1.1.99":
   version: 1.1.99
   resolution: "simple-wappalyzer@npm:1.1.99"
@@ -18079,7 +18268,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"string-width@npm:^7.0.0":
+"string-width@npm:^7.0.0, string-width@npm:^7.2.0":
   version: 7.2.0
   resolution: "string-width@npm:7.2.0"
   dependencies:
@@ -18107,6 +18296,16 @@ __metadata:
     get-east-asian-width: "npm:^1.5.0"
     strip-ansi: "npm:^7.1.2"
   checksum: 10c0/d467b4eaf4c40a01bb438a2620e77badd2456ffd5131c9973abe4f3acf7c802d5b21f3b6a00a5e33a7fc28ca8f9c103226e01bac61e9f259659c6f46d78e353a
+  languageName: node
+  linkType: hard
+
+"string-width@npm:^8.2.1":
+  version: 8.2.2
+  resolution: "string-width@npm:8.2.2"
+  dependencies:
+    get-east-asian-width: "npm:^1.5.0"
+    strip-ansi: "npm:^7.1.2"
+  checksum: 10c0/895624534e4e2f229e880bbc30aa77bdeb758e1a0edce203e0a17b8b4f08b8d3c1156516efc50a35e3efd0052d938a73797692111250ac9f52ee384710a01714
   languageName: node
   linkType: hard
 
@@ -19331,7 +19530,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typed-query-selector@npm:^2.12.0":
+"typed-query-selector@npm:^2.12.0, typed-query-selector@npm:^2.12.2":
   version: 2.12.2
   resolution: "typed-query-selector@npm:2.12.2"
   checksum: 10c0/2710369ada5bde578606b043eefb8a6d7f9178630ae4950a4dfd4f70cceb8196d5bbc735a905cd3e06953127e4dd1825c3e0be06d64e5a6e5609965cffee701d
@@ -20044,6 +20243,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"webdriver-bidi-protocol@npm:0.4.2":
+  version: 0.4.2
+  resolution: "webdriver-bidi-protocol@npm:0.4.2"
+  checksum: 10c0/dd2068949615a4c809949cc590ea7212c82400b21a4150c9ced5bae9b707b21a1dea6edbe52a76519e67835b13e6e036946bbb6c005038b1dccc411c88a9c78e
+  languageName: node
+  linkType: hard
+
 "webidl-conversions@npm:^8.0.0, webidl-conversions@npm:^8.0.1":
   version: 8.0.1
   resolution: "webidl-conversions@npm:8.0.1"
@@ -20429,6 +20635,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"yargs-parser@npm:^22.0.0":
+  version: 22.0.0
+  resolution: "yargs-parser@npm:22.0.0"
+  checksum: 10c0/cb7ef81759c4271cb1d96b9351dbbc9a9ce35d3e1122d2b739bf6c432603824fa02c67cc12dcef6ea80283379d63495686e8f41cc7b06c6576e792aba4d33e1c
+  languageName: node
+  linkType: hard
+
 "yargs@npm:17.7.2, yargs@npm:^17.0.0, yargs@npm:^17.6.2, yargs@npm:^17.7.2":
   version: 17.7.2
   resolution: "yargs@npm:17.7.2"
@@ -20456,6 +20669,20 @@ __metadata:
     y18n: "npm:^5.0.5"
     yargs-parser: "npm:^20.2.2"
   checksum: 10c0/b1dbfefa679848442454b60053a6c95d62f2d2e21dd28def92b647587f415969173c6e99a0f3bab4f1b67ee8283bf735ebe3544013f09491186ba9e8a9a2b651
+  languageName: node
+  linkType: hard
+
+"yargs@npm:^18.0.0":
+  version: 18.1.0
+  resolution: "yargs@npm:18.1.0"
+  dependencies:
+    cliui: "npm:^9.0.1"
+    escalade: "npm:^3.1.1"
+    get-caller-file: "npm:^2.0.5"
+    string-width: "npm:^8.2.1"
+    y18n: "npm:^5.0.5"
+    yargs-parser: "npm:^22.0.0"
+  checksum: 10c0/86052bbed90a9aaaaf1eabe004f47c7420e1b7f8d314170cfb0ad4721f518ec2fb7ba5a6daa20708b1595aba257f1554b2d5b3f5606356f86aa9dae18de0bec5
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- Add `resolvePageLayouts`/`parseLayoutJsonl` to `@d-zero/site-migrator`, resolving each page's
  layout analysis by preferring a pre-generated `@d-zero/anatomist` JSONL file and falling back to
  a live Puppeteer-driven `analyzePageLayout` call for any URL absent from it
- Live failures (network errors, timeouts, navigation errors, or a `newPage()`/`page.close()`
  failure) are classified via `@nitpicker/query`'s `classifyErrorKind` and reported as
  `outcome: 'missing'` through `onResult` rather than thrown, matching `extractPages`'s fail-soft
  design
- The browser is launched lazily (only when a URL actually needs live analysis) and at most once
  across all concurrent workers
- Add `@d-zero/anatomist@0.2.0` and `puppeteer@25.3.0` to `dependencies`

## Scope

This is the first sub-issue of #977 (BurgerEditor block conversion pipeline). Scope is
intentionally limited to the new module (`resolve-page-layout.ts` + its spec) plus the dependency
addition — `cli.ts`/`migrate.ts`/`src/index.ts` are untouched; wiring this into the CLI and the
`extractPages` pipeline is deferred to follow-up sub-issues.

Closes #973

## Test plan

- [x] `yarn build`
- [x] `yarn test` (164 tests, all passing)
- [x] `yarn lint` (0 errors)
