### PR TITLE
feat(site-migrator): convert LayoutBlock tree to BurgerEditor BlockData

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -18,6 +18,9 @@
 		"srcsets",
 		"unstub",
 		"vbscript",
-		"whatwg"
+		"whatwg",
+
+		//
+		"youtu"
 	]
 }

--- a/packages/@d-zero/site-migrator/README.md
+++ b/packages/@d-zero/site-migrator/README.md
@@ -130,6 +130,24 @@ import {
 
 `extractPages` は `extractMainContent` と `getFrontmatter` を並列実行し、生成した YAML ブロックを抽出 HTML の先頭に prepend してから書き出す。整数 id は常に付与されるので「DB 行なし」のページでも `---\nid: <number>\n---\n` ブロックは出る。`getFrontmatter` が例外を投げた場合は fail-soft で id-only frontmatter と本文を書き出し、`onResult` の outcome に `metaError` を載せて警告する（`migrate()` レポートでは `pagesMetaFailed` として集計される）。
 
+### レイアウト → BlockData 変換（`classifyBlockItem` / `layoutToBlockData`）
+
+既存サイトを BurgerEditor ブロックへ移行するパイプライン（親 Issue #977）向けの純関数群。`resolvePageLayouts`（#973 実装済み）と同様、現時点ではパイプライン全体への統合前のため `index.ts` からは export していない（`src/page-extractor/classify-block-item.ts` / `layout-to-block-data.ts` を直接 import する内部 API）。統合とパイプライン公開範囲の判断は #976 で行う。
+
+- `classifyBlockItem(block: LayoutBlock): ClassifiedBlockItem` — anatomist の `LayoutBlock` 1 個を `image`/`title-h2`/`title-h3`/`youtube`/`google-maps`/`download-file`/`button`/`table`/`wysiwyg` の BurgerEditor アイテム種別へヒューリスティック分類する。`children`/`boundingBox`/`confidence` は見ない純関数。
+- `layoutToBlockData(results: LayoutAnalysisResult[], options?): { blocks: BlockData[], fallbacks: {blockIndex, reason}[] }` — 同一 URL の複数ビューポート分の解析結果を受け取り、PC ビューポートを主として深さ圧縮・行列変換・`containerProps` マッピングを行う純関数。`fallbacks` はブロック単位の構造フォールバック（`viewport-mismatch` / `malformed-row-sizes` / `low-confidence`）の理由を記録し、#976 のレポート拡張にそのまま使える。
+
+#### 既知の制限（重要）
+
+anatomist の `LayoutBlock`/`RawLayoutNode` は要素の属性（`href` / `src` / `srcset` / `alt` / `width` / `height` 等）を保持しない（保持されるのは `tagName`/`id`/`classList`/`boundingBox`/`style`/`innerHTML`/`children` のみ）。加えて `should-recurse.ts` の collapse ロジックにより `<picture><source><img></picture>` のようなラッパー構造は最終的に `img` 自身（void 要素、`innerHTML` は空）だけが残る。そのため **実データでは `image` / `youtube` / `google-maps` / `download-file` / `button.link` の判定条件（src/href）がほぼ常に取得できず、safe に `wysiwyg` へフォールバックする**。これはバグではなく、属性情報が存在しないデータに対する意図された安全側の挙動であり、コード自体は正しいロジックを実装している（anatomist が将来属性を捕捉するようになれば自動的に機能する）。anatomist 側の属性キャプチャ拡張は別途フォローアップ課題として扱う。
+
+その他の設計上のポイント:
+
+- `confidence` はコンテナ系 `layoutType`（vertical-stack/horizontal-row/simple-grid/complex-grid/float-wrap）にのみ `0.5` 閾値で二重チェックする。`leaf` の `confidence` は anatomist 側で常に `0` 固定なので、`classifyBlockItem` はこの値を一切参照しない（参照すると分類対象を全て `wysiwyg` に落とす自己矛盾になる）。
+- 深さ圧縮（`BlockData.items` は「ブロック → 行×列 → item」の 2 階層まで）は、depth-2 ノードの `children` を一切読まず `classifyBlockItem` に丸投げすることで実現している。`classifyBlockItem` が `innerHTML` 文字列のみを見るため、depth-3 以降の `layoutType` 情報は自動的に破棄される。
+- `BlockData.name` は固定値 `'migrated'`（ブロックの見た目上の種別名は #975/#976 で命名確定するまでのプレースホルダー）。
+- `download-file` の `size`/`formatedSize` は空文字列のプレースホルダー。実 DL と実サイズの反映は既存の `downloadResources` と連携させて #976 で行う（`classifyBlockItem` はネットワーク I/O を一切行わない）。
+
 ### 設計上の注意
 
 `extractMainContent` / `rewriteAssetRefs` は parse5 を内部で使う純関数、`getFrontmatter` は `@nitpicker/query` の DB 読み出しに依存する。両者の責務分離は `src/html/` (parse5) と `src/archive/` (`@nitpicker/query`) のディレクトリ構造で表現している。

--- a/packages/@d-zero/site-migrator/package.json
+++ b/packages/@d-zero/site-migrator/package.json
@@ -32,6 +32,7 @@
 		"dist"
 	],
 	"dependencies": {
+		"@burger-editor/core": "4.0.0-alpha.65",
 		"@d-zero/anatomist": "0.2.0",
 		"@d-zero/dealer": "1.10.1",
 		"@d-zero/shared": "0.22.2",

--- a/packages/@d-zero/site-migrator/src/page-extractor/classify-block-item.spec.ts
+++ b/packages/@d-zero/site-migrator/src/page-extractor/classify-block-item.spec.ts
@@ -1,0 +1,506 @@
+import type { LayoutBlock } from '@d-zero/anatomist/types';
+
+import { describe, expect, test, vi } from 'vitest';
+
+import { classifyBlockItem } from './classify-block-item.js';
+
+/**
+ * @param overrides
+ */
+function sampleBlock(overrides: Partial<LayoutBlock> = {}): LayoutBlock {
+	return {
+		layoutType: 'leaf',
+		tagName: 'DIV',
+		id: null,
+		classList: [],
+		boundingBox: { x: 0, y: 0, width: 100, height: 100 },
+		innerHTML: '',
+		confidence: 0,
+		signals: {},
+		children: [],
+		...overrides,
+	};
+}
+
+describe('classifyBlockItem', () => {
+	test('layoutType unknown はカテゴリカルゲートで即wysiwygになる（中身を見ない）', () => {
+		const block = sampleBlock({
+			layoutType: 'unknown',
+			tagName: 'DIV',
+			innerHTML: '<h2>見出し</h2>',
+		});
+		const result = classifyBlockItem(block);
+		expect(result.name).toBe('wysiwyg');
+	});
+
+	test('leaf/table以外のlayoutTypeは中身にimgを含んでいてもルールを試さずwysiwygになる', () => {
+		const block = sampleBlock({
+			layoutType: 'complex-grid',
+			confidence: 0.6,
+			tagName: 'DIV',
+			innerHTML: '<img src="a.jpg" alt="a">',
+		});
+		const result = classifyBlockItem(block);
+		expect(result.name).toBe('wysiwyg');
+	});
+
+	test('単一のh2要素（ブロック自身）はtitle-h2になる', () => {
+		const block = sampleBlock({ tagName: 'H2', innerHTML: '見出し' });
+		const result = classifyBlockItem(block);
+		expect(result).toStrictEqual({ name: 'title-h2', data: { titleH2: '見出し' } });
+	});
+
+	test('単一のh3要素（フラグメント内）はtitle-h3になる', () => {
+		const block = sampleBlock({ tagName: 'DIV', innerHTML: '<h3>小見出し</h3>' });
+		const result = classifyBlockItem(block);
+		expect(result).toStrictEqual({ name: 'title-h3', data: { titleH3: '小見出し' } });
+	});
+
+	test('見出し内に内部マークアップがあっても常にtextContentで抽出する', () => {
+		const block = sampleBlock({ tagName: 'H2', innerHTML: '<span>About</span>会社概要' });
+		const result = classifyBlockItem(block);
+		expect(result).toStrictEqual({
+			name: 'title-h2',
+			data: { titleH2: 'About会社概要' },
+		});
+	});
+
+	test('見出し要素に加えて他の要素が混在する場合はwysiwygになる', () => {
+		const block = sampleBlock({
+			tagName: 'DIV',
+			innerHTML: '<h2>見出し</h2><p>本文</p>',
+		});
+		const result = classifyBlockItem(block);
+		expect(result.name).toBe('wysiwyg');
+	});
+
+	test('見出し要素に加えて周囲にテキストがある場合はwysiwygになる', () => {
+		const block = sampleBlock({ tagName: 'DIV', innerHTML: '前置き<h2>見出し</h2>' });
+		const result = classifyBlockItem(block);
+		expect(result.name).toBe('wysiwyg');
+	});
+
+	test('thead/tbodyの単純構造を持つtableはth/tdを正しく抽出する', () => {
+		const block = sampleBlock({
+			layoutType: 'table',
+			tagName: 'TABLE',
+			innerHTML:
+				'<thead><tr><th>名前</th><th>年齢</th></tr></thead><tbody><tr><td>太郎</td><td>20</td></tr></tbody>',
+		});
+		const result = classifyBlockItem(block);
+		expect(result).toStrictEqual({
+			name: 'table',
+			data: { caption: '', th: ['名前', '年齢'], td: ['太郎', '20'], scrollable: false },
+		});
+	});
+
+	test('captionを持つtableはcaptionのテキストを抽出する', () => {
+		const block = sampleBlock({
+			layoutType: 'table',
+			tagName: 'TABLE',
+			innerHTML:
+				'<caption>料金表</caption><thead><tr><th>プラン</th></tr></thead><tbody><tr><td>A</td></tr></tbody>',
+		});
+		const result = classifyBlockItem(block);
+		expect(result).toStrictEqual({
+			name: 'table',
+			data: { caption: '料金表', th: ['プラン'], td: ['A'], scrollable: false },
+		});
+	});
+
+	test('フラグメント内にネストしたtableがある場合も抽出できる', () => {
+		const block = sampleBlock({
+			layoutType: 'leaf',
+			tagName: 'DIV',
+			innerHTML:
+				'<table><thead><tr><th>項目</th></tr></thead><tbody><tr><td>値</td></tr></tbody></table>',
+		});
+		const result = classifyBlockItem(block);
+		expect(result).toStrictEqual({
+			name: 'table',
+			data: { caption: '', th: ['項目'], td: ['値'], scrollable: false },
+		});
+	});
+
+	test('rowspanを含むtableはwysiwygにフォールバックする', () => {
+		const block = sampleBlock({
+			layoutType: 'table',
+			tagName: 'TABLE',
+			innerHTML:
+				'<thead><tr><th>名前</th></tr></thead><tbody><tr><td rowspan="2">太郎</td></tr></tbody>',
+		});
+		const result = classifyBlockItem(block);
+		expect(result.name).toBe('wysiwyg');
+	});
+
+	test('theadが無いtableはwysiwygにフォールバックする', () => {
+		const block = sampleBlock({
+			layoutType: 'table',
+			tagName: 'TABLE',
+			innerHTML: '<tbody><tr><td>値</td></tr></tbody>',
+		});
+		const result = classifyBlockItem(block);
+		expect(result.name).toBe('wysiwyg');
+	});
+
+	test('pictureのsource複数+fallback imgからimageを正しく抽出する（コードの正しさを検証する理想ケース）', () => {
+		const block = sampleBlock({
+			tagName: 'DIV',
+			innerHTML:
+				'<picture><source srcset="a.webp" media="(min-width: 768px)"><img src="b.jpg" alt="説明" width="100" height="50" loading="lazy"></picture>',
+		});
+		const result = classifyBlockItem(block);
+		expect(result).toStrictEqual({
+			name: 'image',
+			data: {
+				path: ['a.webp', 'b.jpg'],
+				alt: ['説明', '説明'],
+				width: [100, 100],
+				height: [50, 50],
+				media: ['(min-width: 768px)', ''],
+				loading: ['lazy', 'lazy'],
+			},
+		});
+	});
+
+	test('picture無しの単一imgは1要素配列のimageになる', () => {
+		const block = sampleBlock({
+			tagName: 'DIV',
+			innerHTML: '<img src="b.jpg" alt="説明" width="100" height="50">',
+		});
+		const result = classifyBlockItem(block);
+		expect(result).toStrictEqual({
+			name: 'image',
+			data: {
+				path: ['b.jpg'],
+				alt: ['説明'],
+				width: [100],
+				height: [50],
+				media: [''],
+				loading: ['eager'],
+			},
+		});
+	});
+
+	test('srcsetがdescriptor付き・複数候補の場合は先頭候補のURLのみを採用する', () => {
+		const block = sampleBlock({
+			tagName: 'DIV',
+			innerHTML:
+				'<picture><source srcset="a.webp 640w, b.webp 1280w"><img src="c.jpg" alt=""></picture>',
+		});
+		const result = classifyBlockItem(block);
+		expect(result).toStrictEqual({
+			name: 'image',
+			data: {
+				path: ['a.webp', 'c.jpg'],
+				alt: ['', ''],
+				width: [0, 0],
+				height: [0, 0],
+				media: ['', ''],
+				loading: ['eager', 'eager'],
+			},
+		});
+	});
+
+	test('picture配下のsourceにsrc/srcsetのいずれも無く有効なpathが1件も取れない場合はwysiwygにフォールバックする', () => {
+		const block = sampleBlock({
+			tagName: 'DIV',
+			innerHTML: '<picture><source media="(min-width: 768px)"></picture>',
+		});
+		const result = classifyBlockItem(block);
+		expect(result.name).toBe('wysiwyg');
+	});
+
+	test('collapseによりimg自身がブロックになった場合（innerHTMLが空、属性取得不能）はwysiwygにフォールバックする', () => {
+		// 実データで高頻度に起きるケース: anatomistのcollapseロジックによりpicture/figure等の
+		// ラッパー情報が失われ、img自身（void要素、innerHTMLは空）だけがLayoutBlockとして残る。
+		const block = sampleBlock({ tagName: 'IMG', innerHTML: '' });
+		const result = classifyBlockItem(block);
+		expect(result.name).toBe('wysiwyg');
+	});
+
+	test('iframe（youtube）はidを抽出し、thumb/urlをBurgerEditor正規形で生成する', () => {
+		const block = sampleBlock({
+			tagName: 'DIV',
+			innerHTML: '<iframe src="https://www.youtube.com/embed/XXXX"></iframe>',
+		});
+		const result = classifyBlockItem(block);
+		expect(result).toStrictEqual({
+			name: 'youtube',
+			data: {
+				id: 'XXXX',
+				title: 'YouTube動画',
+				thumb: '//img.youtube.com/vi/XXXX/maxresdefault.jpg',
+				url: '//www.youtube.com/embed/XXXX?rel=0&loop=1&autoplay=1&autohide=1&start=0',
+			},
+		});
+	});
+
+	test('iframe（youtube）にtitle属性があればそれを使う', () => {
+		const block = sampleBlock({
+			tagName: 'DIV',
+			innerHTML: '<iframe src="https://youtu.be/YYYY" title="紹介動画"></iframe>',
+		});
+		const result = classifyBlockItem(block);
+		expect(result).toStrictEqual({
+			name: 'youtube',
+			data: {
+				id: 'YYYY',
+				title: '紹介動画',
+				thumb: '//img.youtube.com/vi/YYYY/maxresdefault.jpg',
+				url: '//www.youtube.com/embed/YYYY?rel=0&loop=1&autoplay=1&autohide=1&start=0',
+			},
+		});
+	});
+
+	test('iframe（google-maps、@lat,lng形式・zoom指定なし）はlat/lngを抽出しzoomは既定16になる', () => {
+		const block = sampleBlock({
+			tagName: 'DIV',
+			innerHTML: '<iframe src="https://www.google.com/maps?q=35.1,139.1"></iframe>',
+		});
+		const result = classifyBlockItem(block);
+		expect(result).toStrictEqual({
+			name: 'google-maps',
+			data: {
+				lat: 35.1,
+				lng: 139.1,
+				zoom: 16,
+				url: '//maps.apple.com/?q=35.1,139.1',
+				img: '',
+			},
+		});
+	});
+
+	test('iframe（google-maps、@lat,lng,<zoom>z形式）はzoomも抽出する', () => {
+		const block = sampleBlock({
+			tagName: 'DIV',
+			innerHTML: '<iframe src="https://www.google.com/maps/@35.1,139.1,14z"></iframe>',
+		});
+		const result = classifyBlockItem(block);
+		expect(result).toStrictEqual({
+			name: 'google-maps',
+			data: {
+				lat: 35.1,
+				lng: 139.1,
+				zoom: 14,
+				url: '//maps.apple.com/?q=35.1,139.1',
+				img: '',
+			},
+		});
+	});
+
+	test('iframe（google-maps、@lat,lng形式とq=lat,lng形式が両方含まれる場合は@形式を優先する）', () => {
+		const block = sampleBlock({
+			tagName: 'DIV',
+			innerHTML:
+				'<iframe src="https://www.google.com/maps/@35.1,139.1,10z?q=1.1,2.2"></iframe>',
+		});
+		const result = classifyBlockItem(block);
+		expect(result).toStrictEqual({
+			name: 'google-maps',
+			data: {
+				lat: 35.1,
+				lng: 139.1,
+				zoom: 10,
+				url: '//maps.apple.com/?q=35.1,139.1',
+				img: '',
+			},
+		});
+	});
+
+	test('iframe（google-maps、新形式embed?pb=...）はパース不能としてwysiwygにフォールバックする', () => {
+		const block = sampleBlock({
+			tagName: 'DIV',
+			innerHTML: '<iframe src="https://www.google.com/maps/embed?pb=!1m18!2m3"></iframe>',
+		});
+		const result = classifyBlockItem(block);
+		expect(result.name).toBe('wysiwyg');
+	});
+
+	test('既知拡張子かつボタン風クラスを持つaはdownload-fileが勝つ（button優先順位テスト）', () => {
+		const block = sampleBlock({
+			tagName: 'DIV',
+			innerHTML: '<a href="file.pdf" class="c-btn">資料</a>',
+		});
+		const result = classifyBlockItem(block);
+		expect(result).toStrictEqual({
+			name: 'download-file',
+			data: {
+				path: 'file.pdf',
+				download: '',
+				name: 'file.pdf',
+				formatedSize: '',
+				size: '',
+				downloadCheck: false,
+			},
+		});
+	});
+
+	test('クエリ文字列・フラグメント付きのhrefでも拡張子とファイル名を正しく抽出する', () => {
+		const block = sampleBlock({
+			tagName: 'DIV',
+			innerHTML: '<a href="/docs/file.pdf?v=1#top">資料</a>',
+		});
+		const result = classifyBlockItem(block);
+		expect(result).toStrictEqual({
+			name: 'download-file',
+			data: {
+				path: '/docs/file.pdf?v=1#top',
+				download: '',
+				name: 'file.pdf',
+				formatedSize: '',
+				size: '',
+				downloadCheck: false,
+			},
+		});
+	});
+
+	test('ボタン風クラス名は大文字小文字を無視して判定する', () => {
+		const block = sampleBlock({
+			tagName: 'DIV',
+			innerHTML: '<a href="/contact" class="c-Button">お問い合わせ</a>',
+		});
+		const result = classifyBlockItem(block);
+		expect(result.name).toBe('button');
+	});
+
+	test('拡張子なしのボタン風クラスを持つaはbuttonになる', () => {
+		const block = sampleBlock({
+			tagName: 'DIV',
+			innerHTML: '<a href="/contact" class="c-btn">お問い合わせ</a>',
+		});
+		const result = classifyBlockItem(block);
+		expect(result).toStrictEqual({
+			name: 'button',
+			data: {
+				link: '/contact',
+				target: '',
+				text: 'お問い合わせ',
+				subtext: '',
+				kind: 'primary',
+				beforeIcon: 'none',
+				afterIcon: 'none',
+			},
+		});
+	});
+
+	test('a自身にはクラスが無くても親（包むブロック）のクラス名にbtnがあればbuttonになる', () => {
+		const block = sampleBlock({
+			tagName: 'DIV',
+			classList: ['btn-wrap'],
+			innerHTML: '<a href="/contact">お問い合わせ</a>',
+		});
+		const result = classifyBlockItem(block);
+		expect(result.name).toBe('button');
+	});
+
+	test('ブロック自身がaの場合、collapseによりhrefが取得できずbuttonに倒れる', () => {
+		const block = sampleBlock({
+			tagName: 'A',
+			classList: ['c-btn'],
+			innerHTML: 'お問い合わせ',
+		});
+		const result = classifyBlockItem(block);
+		expect(result).toStrictEqual({
+			name: 'button',
+			data: {
+				link: '',
+				target: '',
+				text: 'お問い合わせ',
+				subtext: '',
+				kind: 'primary',
+				beforeIcon: 'none',
+				afterIcon: 'none',
+			},
+		});
+	});
+
+	test('button要素は分類対象外でwysiwygになる', () => {
+		const block = sampleBlock({
+			tagName: 'DIV',
+			innerHTML: '<button class="c-btn">送信</button>',
+		});
+		const result = classifyBlockItem(block);
+		expect(result.name).toBe('wysiwyg');
+	});
+
+	test('ボタンらしさの無いaはwysiwygになる', () => {
+		const block = sampleBlock({
+			tagName: 'DIV',
+			innerHTML: '<a href="/about">会社概要</a>',
+		});
+		const result = classifyBlockItem(block);
+		expect(result.name).toBe('wysiwyg');
+	});
+
+	test('wysiwygフォールバック時はブロック自身のタグ/class/idを再構築してinnerHTMLを包む', () => {
+		const block = sampleBlock({
+			layoutType: 'unknown',
+			tagName: 'SECTION',
+			id: 'news',
+			classList: ['news', 'is-active'],
+			innerHTML: '<p>本文</p>',
+		});
+		const result = classifyBlockItem(block);
+		expect(result).toStrictEqual({
+			name: 'wysiwyg',
+			data: {
+				wysiwyg: '<section class="news is-active" id="news"><p>本文</p></section>',
+			},
+		});
+	});
+
+	test('class/idが無いブロックのwysiwygフォールバックは属性無しの開きタグになる', () => {
+		const block = sampleBlock({
+			layoutType: 'unknown',
+			tagName: 'DIV',
+			innerHTML: '<p>本文</p>',
+		});
+		const result = classifyBlockItem(block);
+		expect(result).toStrictEqual({
+			name: 'wysiwyg',
+			data: { wysiwyg: '<div><p>本文</p></div>' },
+		});
+	});
+
+	test('id/classListにダブルクォート・アンパサンドが含まれる場合、属性境界を壊さずエスケープする', () => {
+		const block = sampleBlock({
+			layoutType: 'unknown',
+			tagName: 'DIV',
+			id: 'a"b&c',
+			classList: ['x"y', 'p&q'],
+			innerHTML: '<p>本文</p>',
+		});
+		const result = classifyBlockItem(block);
+		expect(result).toStrictEqual({
+			name: 'wysiwyg',
+			data: {
+				wysiwyg: '<div class="x&quot;y p&amp;q" id="a&quot;b&amp;c"><p>本文</p></div>',
+			},
+		});
+	});
+
+	test('2個以上の要素が並ぶfragmentはwysiwygになる（クラッシュしない）', () => {
+		const block = sampleBlock({ tagName: 'DIV', innerHTML: '<p>a</p><p>b</p>' });
+		const result = classifyBlockItem(block);
+		expect(result.name).toBe('wysiwyg');
+	});
+
+	test('空のinnerHTMLはwysiwygになる（クラッシュしない）', () => {
+		const block = sampleBlock({ tagName: 'DIV', innerHTML: '' });
+		const result = classifyBlockItem(block);
+		expect(result.name).toBe('wysiwyg');
+	});
+
+	test('download-file分類はfetchを一切呼ばない（純粋関数であることの回帰テスト）', () => {
+		const fetchSpy = vi.spyOn(globalThis, 'fetch');
+		const block = sampleBlock({
+			tagName: 'DIV',
+			innerHTML: '<a href="doc.pdf">資料</a>',
+		});
+		const result = classifyBlockItem(block);
+		expect(result.name).toBe('download-file');
+		expect(fetchSpy).not.toHaveBeenCalled();
+		fetchSpy.mockRestore();
+	});
+});

--- a/packages/@d-zero/site-migrator/src/page-extractor/classify-block-item.ts
+++ b/packages/@d-zero/site-migrator/src/page-extractor/classify-block-item.ts
@@ -512,10 +512,7 @@ function firstSrcsetCandidate(srcset: string | undefined): string | undefined {
  * @param value
  * @param fallback
  */
-function toNumberOrFallback(
-	value: string | undefined,
-	fallback: string | undefined,
-): number {
+function toNumberOrFallback(value: string | undefined, fallback?: string): number {
 	const resolved = value ?? fallback;
 	const parsed = resolved === undefined ? Number.NaN : Number.parseInt(resolved, 10);
 	return Number.isNaN(parsed) ? 0 : parsed;

--- a/packages/@d-zero/site-migrator/src/page-extractor/classify-block-item.ts
+++ b/packages/@d-zero/site-migrator/src/page-extractor/classify-block-item.ts
@@ -1,0 +1,751 @@
+import type { LayoutBlock } from '@d-zero/anatomist/types';
+import type { DefaultTreeAdapterMap } from 'parse5';
+
+import { parseFragment } from 'parse5';
+
+type Element = DefaultTreeAdapterMap['element'];
+type Node = DefaultTreeAdapterMap['childNode'];
+
+export type ImageEntryData = {
+	path: string[];
+	alt: string[];
+	width: number[];
+	height: number[];
+	media: string[];
+	loading: ('eager' | 'lazy')[];
+};
+export type TitleH2Data = { titleH2: string };
+export type TitleH3Data = { titleH3: string };
+export type YoutubeItemData = { id: string; title: string; thumb: string; url: string };
+export type GoogleMapsItemData = {
+	lat: number;
+	lng: number;
+	zoom: number;
+	url: string;
+	img: string;
+};
+export type DownloadFileItemData = {
+	path: string;
+	download: string;
+	name: string;
+	formatedSize: string;
+	size: string;
+	downloadCheck: boolean;
+};
+export type ButtonItemData = {
+	link: string;
+	target: string;
+	text: string;
+	subtext: string;
+	kind: string;
+	beforeIcon: string;
+	afterIcon: string;
+};
+export type TableItemData = {
+	caption: string;
+	th: string[];
+	td: string[];
+	scrollable: boolean;
+};
+export type WysiwygItemData = { wysiwyg: string };
+
+export type ClassifiedBlockItem =
+	| { name: 'image'; data: ImageEntryData }
+	| { name: 'title-h2'; data: TitleH2Data }
+	| { name: 'title-h3'; data: TitleH3Data }
+	| { name: 'youtube'; data: YoutubeItemData }
+	| { name: 'google-maps'; data: GoogleMapsItemData }
+	| { name: 'download-file'; data: DownloadFileItemData }
+	| { name: 'button'; data: ButtonItemData }
+	| { name: 'table'; data: TableItemData }
+	| { name: 'wysiwyg'; data: WysiwygItemData };
+
+/**
+ * ダウンロード対象とみなす拡張子（大文字小文字無視、`.`込みで比較）。
+ * 追加・変更はこの1箇所のみで行う。
+ */
+const DOWNLOADABLE_EXTENSIONS: ReadonlySet<string> = new Set([
+	'.pdf',
+	'.zip',
+	'.doc',
+	'.docx',
+	'.xls',
+	'.xlsx',
+	'.ppt',
+	'.pptx',
+	'.csv',
+	'.tsv',
+	'.lzh',
+	'.7z',
+	'.rar',
+]);
+
+/** ボタン然としたクラス名判定のトークン（部分文字列・大文字小文字無視）。 */
+const BUTTON_CLASS_TOKENS = ['btn', 'button'];
+
+const YOUTUBE_HOST_PATTERN = /youtube\.com|youtu\.be/;
+const GOOGLE_MAPS_HOST_PATTERN = /google\.\w+\/maps/;
+
+/**
+ * 1個の {@link LayoutBlock}（BlockItem 1コマ相当のノード）を、`tagName`/`classList`/
+ * `innerHTML`/`layoutType` だけを根拠に BurgerEditor のアイテム種別へ意味分類する純粋関数。
+ * `children`/`boundingBox`/`confidence` は一切参照しない。
+ *
+ * `confidence` を参照しない理由: `leaf` ノードの `confidence` は anatomist の
+ * `classify-layout-tree.ts`（`toLeafBlock`）により常に `0` 固定であり、これは「意味分類が
+ * 困難」というシグナルではなく「anatomistが子への再帰を止めた」というだけの意味。
+ * image/title/youtube 等の分類対象は通常この `leaf` として現れるため、ここで confidence
+ * 閾値を適用すると分類対象を全て `wysiwyg` に落とす自己矛盾になる（`layout-to-block-data.ts`
+ * 側でコンテナ系 `layoutType` に対して別途 confidence の二重チェックを行う）。
+ *
+ * 判定順序（`@d-zero/anatomist`の`resolve-layout-type.ts`と同じ、素朴な if-else チェーン
+ * ＋JSDocでの優先順位説明のスタイルを踏襲）:
+ *
+ * 1. `layoutType` が `'leaf'`/`'table'` 以外 → 即 `wysiwyg`。複数の意味ある子を持つ構造で
+ *    あることがカテゴリ自体から確定しており、単一アイテムの型に収まらない（`'unknown'` も
+ *    ここで自然に包含される）。
+ * 2. `layoutType === 'table'` またはフラグメント内に `<table>` がある → th/td抽出を試み、
+ *    失敗（rowspan/colspan検出、thead欠如）なら `wysiwyg`。
+ * 3. ブロック自身のタグ、またはフラグメント内の唯一の意味ある要素を対象要素として、
+ *    image/youtube/google-maps/download-file/button/title-h2/title-h3を試す。
+ *    いずれにも該当しなければ `wysiwyg`。
+ *
+ * **重大な制約**: anatomistの`LayoutBlock`/`RawLayoutNode`は要素の属性（`href`/`src`/
+ * `srcset`/`alt`/`width`/`height`等）を保持しない（`tagName`/`id`/`classList`/`boundingBox`/
+ * `style`/`innerHTML`/`children`のみ）。加えて`should-recurse.ts`のcollapseロジックにより
+ * `<picture><source><img></picture>`のようなラッパー構造は最終的に`img`自身（void要素、
+ * `innerHTML`は空）だけが残る。そのため実データでは`image`/`youtube`/`google-maps`/
+ * `download-file`/`button.link`の判定条件（src/href）がほぼ常に取得できず、safeに`wysiwyg`
+ * へフォールバックする。これはバグではなく、属性情報が存在しないデータに対する意図された
+ * 安全側の挙動である。anatomist側の属性キャプチャ拡張は別途フォローアップ課題として扱う。
+ * @param block
+ * @example
+ * ```ts
+ * classifyBlockItem({
+ *   layoutType: 'leaf',
+ *   tagName: 'H2',
+ *   id: null,
+ *   classList: [],
+ *   boundingBox: { x: 0, y: 0, width: 200, height: 40 },
+ *   innerHTML: '見出し',
+ *   confidence: 0,
+ *   signals: {},
+ *   children: [],
+ * });
+ * // => { name: 'title-h2', data: { titleH2: '見出し' } }
+ * ```
+ */
+export function classifyBlockItem(block: LayoutBlock): ClassifiedBlockItem {
+	if (block.layoutType !== 'leaf' && block.layoutType !== 'table') {
+		return wysiwygItem(block);
+	}
+
+	if (block.layoutType === 'table' || fragmentContainsTag(block.innerHTML, 'table')) {
+		return extractTable(block) ?? wysiwygItem(block);
+	}
+
+	const selfTag = block.tagName.toLowerCase();
+
+	if (selfTag === 'h2' || selfTag === 'h3') {
+		return buildTitleItem(selfTag, extractTextContent(parseFragment(block.innerHTML)));
+	}
+
+	if (selfTag === 'a') {
+		// ブロック自身がaの場合、collapseによりhref/親要素の情報は失われている
+		// （LayoutBlockにhrefフィールドが存在しないため常にundefined）。
+		return (
+			classifyAnchorLike(
+				block.classList,
+				undefined,
+				extractTextContent(parseFragment(block.innerHTML)),
+				[],
+			) ?? wysiwygItem(block)
+		);
+	}
+
+	if (selfTag === 'picture') {
+		const image = extractImageFromFragment(parseFragment(block.innerHTML));
+		if (image) {
+			return image;
+		}
+		return wysiwygItem(block);
+	}
+
+	if (selfTag === 'img' || selfTag === 'iframe') {
+		// img: void要素なのでinnerHTMLは常に空。iframe: srcはLayoutBlockに保存されない。
+		// いずれも属性を読む手段が無いため即フォールバック。
+		return wysiwygItem(block);
+	}
+
+	const fragment = parseFragment(block.innerHTML);
+	const topLevel = collectElements(fragment.childNodes);
+	if (topLevel.length !== 1 || hasSignificantText(fragment.childNodes)) {
+		return wysiwygItem(block);
+	}
+	const element = topLevel[0]!;
+	const tag = element.tagName;
+
+	if (tag === 'picture' || tag === 'img') {
+		const image =
+			tag === 'picture'
+				? extractImageFromFragment(fragment, element)
+				: extractImageFromImgElement(element);
+		if (image) {
+			return image;
+		}
+		return wysiwygItem(block);
+	}
+
+	if (tag === 'iframe') {
+		const src = getAttr(element, 'src');
+		if (src === undefined) {
+			return wysiwygItem(block);
+		}
+		if (YOUTUBE_HOST_PATTERN.test(src)) {
+			return buildYoutubeItem(src, getAttr(element, 'title'));
+		}
+		if (GOOGLE_MAPS_HOST_PATTERN.test(src)) {
+			const googleMaps = extractGoogleMaps(src);
+			if (googleMaps) {
+				return googleMaps;
+			}
+		}
+		return wysiwygItem(block);
+	}
+
+	if (tag === 'a') {
+		return (
+			classifyAnchorLike(
+				classListOf(element),
+				getAttr(element, 'href'),
+				extractText(element),
+				block.classList,
+			) ?? wysiwygItem(block)
+		);
+	}
+
+	if (tag === 'h2' || tag === 'h3') {
+		return buildTitleItem(tag, extractText(element));
+	}
+
+	return wysiwygItem(block);
+}
+
+/**
+ * @param tag
+ * @param text
+ */
+function buildTitleItem(
+	tag: 'h2' | 'h3',
+	text: string,
+): { name: 'title-h2'; data: TitleH2Data } | { name: 'title-h3'; data: TitleH3Data } {
+	return tag === 'h2'
+		? { name: 'title-h2', data: { titleH2: text } }
+		: { name: 'title-h3', data: { titleH3: text } };
+}
+
+/**
+ * `<a>`（BurgerEditorの`<button>`アイテムはこの分類対象外 — ボタン然とした`<a>`のみを
+ * `button`として扱う）を`download-file`/`button`/`wysiwyg`へ分類する。`href`の拡張子判定を
+ * `button`のクラス名ヒューリスティックより先に試す: 拡張子は構造的・決定論的なシグナルで
+ * あり、ボタン風クラス名という曖昧な判定より優先すべきため（例: PDFリンクがボタン風クラスを
+ * 持っていても`download-file`としての機能的な意味を優先する）。
+ * @param ownClassList
+ * @param href
+ * @param text
+ * @param ancestorClassList - このリンクを包む祖先ブロックのclassList（「親要素のクラス名」も
+ *   ボタン判定の手がかりに使う）。ブロック自身がaの場合はcollapseで祖先情報が失われているため空配列。
+ * @returns どちらにも該当しなければ`undefined`（呼び出し側が`wysiwygItem(block)`でフォール
+ *   バックする — ラッパータグ再構築を一箇所に集約するため、ここでは`wysiwyg`を組み立てない）。
+ */
+function classifyAnchorLike(
+	ownClassList: readonly string[],
+	href: string | undefined,
+	text: string,
+	ancestorClassList: readonly string[],
+):
+	| { name: 'download-file'; data: DownloadFileItemData }
+	| { name: 'button'; data: ButtonItemData }
+	| undefined {
+	if (href !== undefined) {
+		const extension = extractExtension(href);
+		if (extension !== undefined && DOWNLOADABLE_EXTENSIONS.has(extension)) {
+			return buildDownloadFileItem(href);
+		}
+	}
+
+	if (hasButtonLikeClass(ownClassList) || hasButtonLikeClass(ancestorClassList)) {
+		return {
+			name: 'button',
+			data: {
+				link: href ?? '',
+				target: '',
+				text,
+				subtext: '',
+				kind: 'primary',
+				beforeIcon: 'none',
+				afterIcon: 'none',
+			},
+		};
+	}
+
+	return undefined;
+}
+
+/**
+ * @param classList
+ */
+function hasButtonLikeClass(classList: readonly string[]): boolean {
+	return classList.some((className) => {
+		const lower = className.toLowerCase();
+		return BUTTON_CLASS_TOKENS.some((token) => lower.includes(token));
+	});
+}
+
+/**
+ * @param href
+ */
+function buildDownloadFileItem(href: string): {
+	name: 'download-file';
+	data: DownloadFileItemData;
+} {
+	return {
+		name: 'download-file',
+		data: {
+			path: href,
+			download: '',
+			name: basename(href),
+			formatedSize: '',
+			size: '',
+			downloadCheck: false,
+		},
+	};
+}
+
+/**
+ * @param href
+ */
+function extractExtension(href: string): string | undefined {
+	const withoutQuery = href.split(/[#?]/u)[0] ?? '';
+	const match = /\.[a-z0-9]+$/i.exec(withoutQuery);
+	return match?.[0].toLowerCase();
+}
+
+/**
+ * @param href
+ */
+function basename(href: string): string {
+	const withoutQuery = href.split(/[#?]/u)[0] ?? '';
+	const segments = withoutQuery.split('/');
+	return segments.at(-1) ?? href;
+}
+
+const YOUTUBE_ID_PATTERN = /(?:embed\/|v=|youtu\.be\/)([\w-]+)/;
+const YOUTUBE_FALLBACK_TITLE = 'YouTube動画';
+
+/**
+ * BurgerEditor本体（`@burger-editor/blocks`の`items/youtube/index.tsx`）の`toItemData`が
+ * 生成する正規形（`maxresdefault.jpg`・パラメータ付きembed URL）に合わせる。#975のrender・
+ * #980の往復検証が本体の正規形と一致している必要があるため。
+ * @param src
+ * @param title
+ */
+function buildYoutubeItem(
+	src: string,
+	title: string | undefined,
+): { name: 'youtube'; data: YoutubeItemData } {
+	const match = YOUTUBE_ID_PATTERN.exec(src);
+	const id = match?.[1] ?? '';
+	return {
+		name: 'youtube',
+		data: {
+			id,
+			title: title || YOUTUBE_FALLBACK_TITLE,
+			thumb: `//img.youtube.com/vi/${id}/maxresdefault.jpg`,
+			url: `//www.youtube.com/embed/${id}?rel=0&loop=1&autoplay=1&autohide=1&start=0`,
+		},
+	};
+}
+
+const GOOGLE_MAPS_AT_PATTERN = /@(-?\d+\.\d+),(-?\d+\.\d+)(?:,(\d+)z)?/;
+const GOOGLE_MAPS_Q_PATTERN = /[?&]q=(-?\d+\.\d+),(-?\d+\.\d+)/;
+const DEFAULT_GOOGLE_MAPS_ZOOM = 16;
+
+/**
+ * `@lat,lng`または`q=lat,lng`のシンプルな平文embed形式のみ対応する。新形式
+ * `embed?pb=...`（実質パース不可能なprotocol bufferエンコード）はいずれのパターンにも
+ * マッチせず`undefined`を返し、呼び出し側が`wysiwyg`にフォールバックする。
+ * @param src
+ */
+function extractGoogleMaps(
+	src: string,
+): { name: 'google-maps'; data: GoogleMapsItemData } | undefined {
+	const atMatch = GOOGLE_MAPS_AT_PATTERN.exec(src);
+	const match = atMatch ?? GOOGLE_MAPS_Q_PATTERN.exec(src);
+	if (!match) {
+		return undefined;
+	}
+	const lat = Number.parseFloat(match[1]!);
+	const lng = Number.parseFloat(match[2]!);
+	const zoomText = atMatch?.[3];
+	const zoom =
+		zoomText === undefined ? DEFAULT_GOOGLE_MAPS_ZOOM : Number.parseInt(zoomText, 10);
+	return {
+		name: 'google-maps',
+		data: {
+			lat,
+			lng,
+			zoom,
+			url: `//maps.apple.com/?q=${lat},${lng}`,
+			img: '',
+		},
+	};
+}
+
+/**
+ * `<picture>`配下の`<source>`/`<img>`を文書順に1エントリとして拾い、`path`/`alt`/`width`/
+ * `height`/`media`/`loading`の配列を構築する。`path`が1件も取れない場合（属性を持つ
+ * `<source>`/`<img>`が実際には無い、実データで高頻度に起きるケース）は`undefined`を返し、
+ * 呼び出し側が`wysiwyg`にフォールバックする。
+ * @param fragment
+ * @param pictureElement - 既に特定済みの`<picture>`要素があれば渡す（child-caseで二重に
+ *   トップレベル走査しないため）。無ければ`fragment`のトップレベル`<picture>`を探す。
+ */
+function extractImageFromFragment(
+	fragment: DefaultTreeAdapterMap['documentFragment'],
+	pictureElement?: Element,
+): { name: 'image'; data: ImageEntryData } | undefined {
+	const picture =
+		pictureElement ??
+		collectElements(fragment.childNodes).find((el) => el.tagName === 'picture');
+	const sourceAndImgElements = picture
+		? collectElements(picture.childNodes)
+		: collectElements(fragment.childNodes);
+	const candidates = sourceAndImgElements.filter(
+		(el) => el.tagName === 'source' || el.tagName === 'img',
+	);
+	if (candidates.length === 0) {
+		return undefined;
+	}
+
+	const fallbackImg = candidates.find((el) => el.tagName === 'img');
+	const fallbackAlt = fallbackImg ? (getAttr(fallbackImg, 'alt') ?? '') : '';
+	const fallbackLoading = normalizeLoading(
+		fallbackImg ? getAttr(fallbackImg, 'loading') : undefined,
+	);
+
+	const path: string[] = [];
+	const alt: string[] = [];
+	const width: number[] = [];
+	const height: number[] = [];
+	const media: string[] = [];
+	const loading: ('eager' | 'lazy')[] = [];
+
+	for (const el of candidates) {
+		const isImg = el.tagName === 'img';
+		const srcsetOrSrc = isImg
+			? getAttr(el, 'src')
+			: (firstSrcsetCandidate(getAttr(el, 'srcset')) ?? getAttr(el, 'src'));
+		if (srcsetOrSrc === undefined) {
+			continue;
+		}
+		path.push(srcsetOrSrc);
+		alt.push(fallbackAlt);
+		width.push(
+			toNumberOrFallback(
+				getAttr(el, 'width'),
+				fallbackImg ? getAttr(fallbackImg, 'width') : undefined,
+			),
+		);
+		height.push(
+			toNumberOrFallback(
+				getAttr(el, 'height'),
+				fallbackImg ? getAttr(fallbackImg, 'height') : undefined,
+			),
+		);
+		media.push(isImg ? '' : (getAttr(el, 'media') ?? ''));
+		loading.push(fallbackLoading);
+	}
+
+	if (path.length === 0) {
+		return undefined;
+	}
+
+	return { name: 'image', data: { path, alt, width, height, media, loading } };
+}
+
+/**
+ * @param element
+ */
+function extractImageFromImgElement(
+	element: Element,
+): { name: 'image'; data: ImageEntryData } | undefined {
+	const src = getAttr(element, 'src');
+	if (src === undefined) {
+		return undefined;
+	}
+	return {
+		name: 'image',
+		data: {
+			path: [src],
+			alt: [getAttr(element, 'alt') ?? ''],
+			width: [toNumberOrFallback(getAttr(element, 'width'))],
+			height: [toNumberOrFallback(getAttr(element, 'height'))],
+			media: [''],
+			loading: [normalizeLoading(getAttr(element, 'loading'))],
+		},
+	};
+}
+
+/**
+ * @param srcset
+ */
+function firstSrcsetCandidate(srcset: string | undefined): string | undefined {
+	if (srcset === undefined) {
+		return undefined;
+	}
+	const first = srcset.split(',')[0]?.trim();
+	return first?.split(/\s+/u)[0];
+}
+
+/**
+ * @param value
+ * @param fallback
+ */
+function toNumberOrFallback(
+	value: string | undefined,
+	fallback: string | undefined,
+): number {
+	const resolved = value ?? fallback;
+	const parsed = resolved === undefined ? Number.NaN : Number.parseInt(resolved, 10);
+	return Number.isNaN(parsed) ? 0 : parsed;
+}
+
+/**
+ * @param loading
+ */
+function normalizeLoading(loading: string | undefined): 'eager' | 'lazy' {
+	return loading === 'lazy' ? 'lazy' : 'eager';
+}
+
+const THEAD_TH_PATTERN = /<thead[^>]*>[\s\S]*?<\/thead>/i;
+
+/**
+ * `<table><thead><tr><th>`/`<tbody><tr><td>`のシンプル構造のみ対応する。`rowspan`/`colspan`、
+ * ネストした`thead`無しテーブルは非対応（`TableData`自体rowspan非対応のため自然な制約）で
+ * `undefined`を返し、呼び出し側が`wysiwyg`にフォールバックする。
+ * @param block
+ */
+function extractTable(
+	block: LayoutBlock,
+): { name: 'table'; data: TableItemData } | undefined {
+	const fragment = parseFragment(block.innerHTML);
+	// `block.tagName==='table'`のとき、`innerHTML`は`<table>`自身の内側（`thead`/`tbody`等）
+	// であって`<table>`タグそのものは含まれないため、fragment直下を`table`の子ノードとして
+	// 扱う。それ以外（フラグメント内に`<table>`が入れ子で存在するケース）はその子ノードを使う。
+	const tableChildNodes =
+		block.tagName.toLowerCase() === 'table'
+			? fragment.childNodes
+			: findElementByTag(fragment.childNodes, 'table')?.childNodes;
+	if (!tableChildNodes) {
+		return undefined;
+	}
+
+	const html = block.innerHTML;
+	if (!THEAD_TH_PATTERN.test(html)) {
+		return undefined;
+	}
+	if (/rowspan|colspan/i.test(html)) {
+		return undefined;
+	}
+
+	const thead = findElementByTag(tableChildNodes, 'thead');
+	const tbody = findElementByTag(tableChildNodes, 'tbody');
+	if (!thead || !tbody) {
+		return undefined;
+	}
+
+	const th = findElementsByTag(thead.childNodes, 'th').map((el) => extractText(el));
+	const td = findElementsByTag(tbody.childNodes, 'td').map((el) => extractText(el));
+	const caption = findElementByTag(tableChildNodes, 'caption');
+
+	return {
+		name: 'table',
+		data: {
+			caption: caption ? extractText(caption) : '',
+			th,
+			td,
+			scrollable: false,
+		},
+	};
+}
+
+/**
+ * @param html
+ * @param tag
+ */
+function fragmentContainsTag(html: string, tag: string): boolean {
+	const fragment = parseFragment(html);
+	return findElementByTag(fragment.childNodes, tag) !== undefined;
+}
+
+/**
+ * @param nodes
+ * @param tag
+ */
+function findElementByTag(nodes: readonly Node[], tag: string): Element | undefined {
+	for (const node of nodes) {
+		if (isElement(node)) {
+			if (node.tagName === tag) {
+				return node;
+			}
+			const nested = findElementByTag(node.childNodes, tag);
+			if (nested) {
+				return nested;
+			}
+		}
+	}
+	return undefined;
+}
+
+/**
+ * @param nodes
+ * @param tag
+ */
+function findElementsByTag(nodes: readonly Node[], tag: string): Element[] {
+	const result: Element[] = [];
+	for (const node of nodes) {
+		if (isElement(node)) {
+			if (node.tagName === tag) {
+				result.push(node);
+			}
+			result.push(...findElementsByTag(node.childNodes, tag));
+		}
+	}
+	return result;
+}
+
+const WHITESPACE_ONLY = /^\s*$/;
+
+/**
+ * 直下の要素ノードを文書順に返す（テキスト・コメントノードは除外）。
+ * @param nodes
+ */
+function collectElements(nodes: readonly Node[]): Element[] {
+	return nodes.filter((node): node is Element => isElement(node));
+}
+
+/**
+ * 直下に空白以外のテキストノードが存在するかを判定する。「唯一の意味ある要素」判定で、
+ * 要素の個数だけでなく周囲のテキスト（例: `<p>説明文<a>…</a></p>`の"説明文"）の有無も
+ * 考慮するために使う。
+ * @param nodes
+ */
+function hasSignificantText(nodes: readonly Node[]): boolean {
+	return nodes.some(
+		(node) => !isElement(node) && 'value' in node && !WHITESPACE_ONLY.test(node.value),
+	);
+}
+
+/**
+ * @param node
+ */
+function isElement(node: Node): node is Element {
+	return 'tagName' in node && Array.isArray((node as Element).attrs);
+}
+
+/**
+ * @param element
+ * @param name
+ */
+function getAttr(element: Element, name: string): string | undefined {
+	for (const attribute of element.attrs) {
+		if (attribute.name === name) {
+			return attribute.value;
+		}
+	}
+	return undefined;
+}
+
+/**
+ * @param element
+ */
+function classListOf(element: Element): string[] {
+	const className = getAttr(element, 'class');
+	if (className === undefined) {
+		return [];
+	}
+	return className.split(/\s+/u).filter((token) => token.length > 0);
+}
+
+/**
+ * 要素配下のテキストノードを文書順に連結する（`textContent`相当）。内部マークアップの
+ * 有無に関わらず常にこの方法で見出し等のテキストを抽出する。
+ * @param element
+ */
+function extractText(element: Element): string {
+	return extractTextFromNodes(element.childNodes);
+}
+
+/**
+ * @param fragment
+ */
+function extractTextContent(fragment: DefaultTreeAdapterMap['documentFragment']): string {
+	return extractTextFromNodes(fragment.childNodes);
+}
+
+/**
+ * @param nodes
+ */
+function extractTextFromNodes(nodes: readonly Node[]): string {
+	let text = '';
+	for (const node of nodes) {
+		if (isElement(node)) {
+			text += extractTextFromNodes(node.childNodes);
+		} else if ('value' in node) {
+			text += node.value;
+		}
+	}
+	return text.trim();
+}
+
+/**
+ * ブロック単位のフォールバック（ビューポート不一致、`rowSizes`不正形状等）で
+ * `layout-to-block-data.ts` からも使う、無条件の `wysiwyg` ビルダー。
+ * @param block
+ */
+export function wysiwygItem(block: LayoutBlock): {
+	name: 'wysiwyg';
+	data: WysiwygItemData;
+} {
+	return { name: 'wysiwyg', data: { wysiwyg: wrapWithOwnTag(block) } };
+}
+
+/**
+ * ブロック自身のタグ（`tagName`/`id`/`classList`）を再構築して`innerHTML`を包む。
+ * `style`/`data-*`等の他の属性はanatomistが捕捉していないため失われるが、構造とCSS
+ * フック（class）は保持される。
+ * @param block
+ */
+function wrapWithOwnTag(block: LayoutBlock): string {
+	const tag = block.tagName.toLowerCase();
+	const attrs: string[] = [];
+	if (block.classList.length > 0) {
+		attrs.push(`class="${escapeAttribute(block.classList.join(' '))}"`);
+	}
+	if (block.id) {
+		attrs.push(`id="${escapeAttribute(block.id)}"`);
+	}
+	const openTag = attrs.length > 0 ? `<${tag} ${attrs.join(' ')}>` : `<${tag}>`;
+	return `${openTag}${block.innerHTML}</${tag}>`;
+}
+
+/**
+ * `class`/`id`をダブルクォート属性値として埋め込む前にエスケープする。anatomistが
+ * `classList`/`id`をDOMプロパティの生値として捕捉しているため（`"`を含むid等が理論上
+ * 可能）、無害化せずに埋め込むと属性境界が壊れHTML構造が破損する。
+ * @param value
+ */
+function escapeAttribute(value: string): string {
+	return value.replaceAll('&', '&amp;').replaceAll('"', '&quot;');
+}

--- a/packages/@d-zero/site-migrator/src/page-extractor/layout-to-block-data.spec.ts
+++ b/packages/@d-zero/site-migrator/src/page-extractor/layout-to-block-data.spec.ts
@@ -1,0 +1,432 @@
+import type { LayoutAnalysisResult, LayoutBlock } from '@d-zero/anatomist/types';
+
+import { describe, expect, test } from 'vitest';
+
+import { layoutToBlockData } from './layout-to-block-data.js';
+
+/**
+ * @param overrides
+ */
+function sampleBlock(overrides: Partial<LayoutBlock> = {}): LayoutBlock {
+	return {
+		layoutType: 'leaf',
+		tagName: 'DIV',
+		id: null,
+		classList: [],
+		boundingBox: { x: 0, y: 0, width: 100, height: 100 },
+		innerHTML: '',
+		confidence: 0,
+		signals: {},
+		children: [],
+		...overrides,
+	};
+}
+
+/**
+ * @param overrides
+ */
+function sampleResult(
+	overrides: Partial<LayoutAnalysisResult> = {},
+): LayoutAnalysisResult {
+	return {
+		url: 'https://example.com/',
+		viewport: { name: 'pc', width: 1280 },
+		mainSelector: 'main',
+		root: sampleBlock(),
+		...overrides,
+	};
+}
+
+const heading = (text: string) => sampleBlock({ tagName: 'H2', innerHTML: text });
+
+describe('layoutToBlockData', () => {
+	test('vertical-stackはN児をN行1列に変換する', () => {
+		const depth1 = sampleBlock({
+			layoutType: 'vertical-stack',
+			confidence: 0.8,
+			children: [heading('見出し1'), heading('見出し2')],
+		});
+		const result = layoutToBlockData([
+			sampleResult({ root: sampleBlock({ children: [depth1] }) }),
+		]);
+
+		expect(result.blocks).toHaveLength(1);
+		expect(result.blocks[0]!.containerProps).toStrictEqual({ type: 'grid', columns: 1 });
+		expect(result.blocks[0]!.items).toStrictEqual([
+			[{ name: 'title-h2', data: { titleH2: '見出し1' } }],
+			[{ name: 'title-h2', data: { titleH2: '見出し2' } }],
+		]);
+		expect(result.fallbacks).toStrictEqual([]);
+	});
+
+	test('horizontal-rowはN児を1行N列に変換する', () => {
+		const depth1 = sampleBlock({
+			layoutType: 'horizontal-row',
+			confidence: 0.8,
+			children: [heading('見出し1'), heading('見出し2')],
+		});
+		const result = layoutToBlockData([
+			sampleResult({ root: sampleBlock({ children: [depth1] }) }),
+		]);
+
+		expect(result.blocks[0]!.containerProps).toStrictEqual({ type: 'inline' });
+		expect(result.blocks[0]!.items).toStrictEqual([
+			[
+				{ name: 'title-h2', data: { titleH2: '見出し1' } },
+				{ name: 'title-h2', data: { titleH2: '見出し2' } },
+			],
+		]);
+	});
+
+	test('simple-gridはsignals.rowSizesに基づき正しく行分割する', () => {
+		const children = Array.from({ length: 8 }, (_, i) => heading(`item${i}`));
+		const depth1 = sampleBlock({
+			layoutType: 'simple-grid',
+			confidence: 0.85,
+			signals: { rowSizes: [3, 3, 2] },
+			children,
+		});
+		const result = layoutToBlockData([
+			sampleResult({ root: sampleBlock({ children: [depth1] }) }),
+		]);
+
+		expect(result.blocks[0]!.containerProps).toStrictEqual({ type: 'grid', columns: 3 });
+		expect(result.blocks[0]!.items).toHaveLength(3);
+		expect(result.blocks[0]!.items[0]).toHaveLength(3);
+		expect(result.blocks[0]!.items[1]).toHaveLength(3);
+		expect(result.blocks[0]!.items[2]).toHaveLength(2);
+		expect(result.fallbacks).toStrictEqual([]);
+	});
+
+	test('float-wrapはすべて1行になり、signalsに方向情報が無ければfloatはnullになる', () => {
+		const depth1 = sampleBlock({
+			layoutType: 'float-wrap',
+			confidence: 0.75,
+			children: [heading('見出し1'), heading('見出し2')],
+		});
+		const result = layoutToBlockData([
+			sampleResult({ root: sampleBlock({ children: [depth1] }) }),
+		]);
+
+		expect(result.blocks[0]!.containerProps).toStrictEqual({
+			type: 'float',
+			float: null,
+		});
+		expect(result.blocks[0]!.items).toHaveLength(1);
+		expect(result.blocks[0]!.items[0]).toHaveLength(2);
+	});
+
+	test('float-wrapはsignals.floatに方向情報があればContainerProps.floatに反映する（将来anatomistが対応した場合の先行実装）', () => {
+		const depth1 = sampleBlock({
+			layoutType: 'float-wrap',
+			confidence: 0.75,
+			signals: { float: 'start' },
+			children: [heading('見出し1'), heading('見出し2')],
+		});
+		const result = layoutToBlockData([
+			sampleResult({ root: sampleBlock({ children: [depth1] }) }),
+		]);
+
+		expect(result.blocks[0]!.containerProps).toStrictEqual({
+			type: 'float',
+			float: 'start',
+		});
+	});
+
+	test('table/unknown/leafのdepth-1ノードは1行1列の単一itemになる', () => {
+		const depth1 = sampleBlock({
+			layoutType: 'table',
+			tagName: 'TABLE',
+			innerHTML:
+				'<thead><tr><th>項目</th></tr></thead><tbody><tr><td>値</td></tr></tbody>',
+		});
+		const result = layoutToBlockData([
+			sampleResult({ root: sampleBlock({ children: [depth1] }) }),
+		]);
+
+		expect(result.blocks[0]!.containerProps).toStrictEqual({ type: 'grid', columns: 1 });
+		expect(result.blocks[0]!.items).toStrictEqual([
+			[
+				{
+					name: 'table',
+					data: { caption: '', th: ['項目'], td: ['値'], scrollable: false },
+				},
+			],
+		]);
+	});
+
+	test('rowSizesが存在しないsimple-gridはwysiwyg単一アイテムに倒れ、malformed-row-sizesが記録される', () => {
+		const depth1 = sampleBlock({
+			layoutType: 'simple-grid',
+			confidence: 0.85,
+			tagName: 'DIV',
+			classList: ['grid'],
+			innerHTML: '<p>a</p><p>b</p>',
+			children: [heading('a'), heading('b')],
+		});
+		const result = layoutToBlockData([
+			sampleResult({ root: sampleBlock({ children: [depth1] }) }),
+		]);
+
+		expect(result.blocks[0]!.items).toStrictEqual([
+			[
+				{
+					name: 'wysiwyg',
+					data: { wysiwyg: '<div class="grid"><p>a</p><p>b</p></div>' },
+				},
+			],
+		]);
+		expect(result.fallbacks).toStrictEqual([
+			{ blockIndex: 0, reason: 'malformed-row-sizes' },
+		]);
+	});
+
+	test('rowSizesが非配列のsimple-gridはwysiwygに倒れる', () => {
+		const depth1 = sampleBlock({
+			layoutType: 'simple-grid',
+			confidence: 0.85,
+			signals: { rowSizes: 'not-an-array' },
+			children: [heading('a'), heading('b')],
+		});
+		const result = layoutToBlockData([
+			sampleResult({ root: sampleBlock({ children: [depth1] }) }),
+		]);
+
+		expect(result.blocks[0]!.items[0]![0]).toMatchObject({ name: 'wysiwyg' });
+		expect(result.fallbacks[0]).toStrictEqual({
+			blockIndex: 0,
+			reason: 'malformed-row-sizes',
+		});
+	});
+
+	test('rowSizesが空配列のsimple-gridはwysiwygに倒れる（columnsがMath.maxの空適用で-Infinityになることを防ぐ）', () => {
+		const depth1 = sampleBlock({
+			layoutType: 'simple-grid',
+			confidence: 0.85,
+			signals: { rowSizes: [] },
+			children: [],
+		});
+		const result = layoutToBlockData([
+			sampleResult({ root: sampleBlock({ children: [depth1] }) }),
+		]);
+
+		expect(result.blocks[0]!.containerProps).not.toHaveProperty(
+			'columns',
+			Number.NEGATIVE_INFINITY,
+		);
+		expect(result.fallbacks[0]).toStrictEqual({
+			blockIndex: 0,
+			reason: 'malformed-row-sizes',
+		});
+	});
+
+	test('rowSizesの合計がchildren数と不一致なsimple-gridはwysiwygに倒れる', () => {
+		const depth1 = sampleBlock({
+			layoutType: 'simple-grid',
+			confidence: 0.85,
+			signals: { rowSizes: [2, 2] },
+			children: [heading('a'), heading('b'), heading('c')],
+		});
+		const result = layoutToBlockData([
+			sampleResult({ root: sampleBlock({ children: [depth1] }) }),
+		]);
+
+		expect(result.fallbacks[0]).toStrictEqual({
+			blockIndex: 0,
+			reason: 'malformed-row-sizes',
+		});
+	});
+
+	test('コンテナ系confidenceが閾値未満の場合はlow-confidenceとしてwysiwygに倒れる', () => {
+		const depth1 = sampleBlock({
+			layoutType: 'vertical-stack',
+			confidence: 0.1,
+			children: [heading('a'), heading('b')],
+		});
+		const result = layoutToBlockData([
+			sampleResult({ root: sampleBlock({ children: [depth1] }) }),
+		]);
+
+		expect(result.blocks[0]!.items[0]![0]).toMatchObject({ name: 'wysiwyg' });
+		expect(result.fallbacks[0]).toStrictEqual({
+			blockIndex: 0,
+			reason: 'low-confidence',
+		});
+	});
+
+	test('PC/モバイルで同一indexの子要素数が不一致の場合、そのブロックのみwysiwygになり他は正常に分類される', () => {
+		const pcMatching = sampleBlock({
+			layoutType: 'vertical-stack',
+			confidence: 0.8,
+			children: [heading('a')],
+		});
+		const pcMismatching = sampleBlock({
+			layoutType: 'vertical-stack',
+			confidence: 0.8,
+			tagName: 'DIV',
+			innerHTML: '<p>x</p><p>y</p>',
+			children: [heading('x'), heading('y')],
+		});
+		const pcRoot = sampleBlock({ children: [pcMatching, pcMismatching] });
+
+		const spMatching = sampleBlock({
+			layoutType: 'vertical-stack',
+			confidence: 0.8,
+			children: [heading('a')],
+		});
+		const spMismatching = sampleBlock({
+			layoutType: 'vertical-stack',
+			confidence: 0.8,
+			children: [heading('x')],
+		});
+		const spRoot = sampleBlock({ children: [spMatching, spMismatching] });
+
+		const result = layoutToBlockData([
+			sampleResult({ viewport: { name: 'pc', width: 1280 }, root: pcRoot }),
+			sampleResult({ viewport: { name: 'sp', width: 375 }, root: spRoot }),
+		]);
+
+		expect(result.blocks).toHaveLength(2);
+		// index 0: 子要素数一致 → 正常分類
+		expect(result.blocks[0]!.items).toStrictEqual([
+			[{ name: 'title-h2', data: { titleH2: 'a' } }],
+		]);
+		// index 1: 子要素数不一致（PC:2 vs SP:1） → ブロック全体がwysiwygに倒れる
+		expect(result.blocks[1]!.items[0]![0]).toStrictEqual({
+			name: 'wysiwyg',
+			data: { wysiwyg: '<div><p>x</p><p>y</p></div>' },
+		});
+		expect(result.fallbacks).toStrictEqual([
+			{ blockIndex: 1, reason: 'viewport-mismatch' },
+		]);
+	});
+
+	test('他ビューポート側のrootがnullの場合は不一致として扱う', () => {
+		const pcRoot = sampleBlock({
+			children: [
+				sampleBlock({
+					layoutType: 'vertical-stack',
+					confidence: 0.8,
+					children: [heading('a')],
+				}),
+			],
+		});
+		const result = layoutToBlockData([
+			sampleResult({ viewport: { name: 'pc', width: 1280 }, root: pcRoot }),
+			sampleResult({ viewport: { name: 'sp', width: 375 }, root: null }),
+		]);
+
+		expect(result.fallbacks).toStrictEqual([
+			{ blockIndex: 0, reason: 'viewport-mismatch' },
+		]);
+	});
+
+	test('単一ビューポートのみの入力ではビューポート整合性チェックをスキップして通常変換する', () => {
+		const depth1 = sampleBlock({
+			layoutType: 'vertical-stack',
+			confidence: 0.8,
+			children: [heading('a')],
+		});
+		const result = layoutToBlockData([
+			sampleResult({ root: sampleBlock({ children: [depth1] }) }),
+		]);
+
+		expect(result.fallbacks).toStrictEqual([]);
+		expect(result.blocks[0]!.items).toStrictEqual([
+			[{ name: 'title-h2', data: { titleH2: 'a' } }],
+		]);
+	});
+
+	test('primary.rootがnullの場合は空配列を返す', () => {
+		const result = layoutToBlockData([sampleResult({ root: null })]);
+		expect(result).toStrictEqual({ blocks: [], fallbacks: [] });
+	});
+
+	test('resultsが空配列の場合は空配列を返す', () => {
+		const result = layoutToBlockData([]);
+		expect(result).toStrictEqual({ blocks: [], fallbacks: [] });
+	});
+
+	test('深さ圧縮: depth-2ノードがchildrenを持つ非tableの場合でもchildrenを見ずclassifyBlockItemに丸投げされる', () => {
+		const deepGrandchild = sampleBlock({ tagName: 'SPAN', innerHTML: '深すぎる内容' });
+		const depth2NonLeaf = sampleBlock({
+			layoutType: 'horizontal-row',
+			confidence: 0.8,
+			tagName: 'DIV',
+			innerHTML: '<p>深い内容</p>',
+			children: [deepGrandchild, deepGrandchild],
+		});
+		const depth1 = sampleBlock({
+			layoutType: 'vertical-stack',
+			confidence: 0.8,
+			children: [depth2NonLeaf],
+		});
+		const result = layoutToBlockData([
+			sampleResult({ root: sampleBlock({ children: [depth1] }) }),
+		]);
+
+		// depth2ノード自身のlayoutTypeがleaf/table以外なのでカテゴリカルゲートでwysiwygになり、
+		// innerHTML（"<p>深い内容</p>"）だけが使われる。孫（"深すぎる内容"）は結果に一切現れない。
+		expect(result.blocks[0]!.items).toStrictEqual([
+			[{ name: 'wysiwyg', data: { wysiwyg: '<div><p>深い内容</p></div>' } }],
+		]);
+	});
+
+	test('primaryViewportNameを指定しない場合は既定で"pc"が優先される', () => {
+		const pcRoot = sampleBlock({
+			children: [
+				sampleBlock({
+					layoutType: 'vertical-stack',
+					confidence: 0.8,
+					children: [heading('pc')],
+				}),
+			],
+		});
+		const spRoot = sampleBlock({
+			children: [
+				sampleBlock({
+					layoutType: 'vertical-stack',
+					confidence: 0.8,
+					children: [heading('sp')],
+				}),
+			],
+		});
+		const result = layoutToBlockData([
+			sampleResult({ viewport: { name: 'sp', width: 375 }, root: spRoot }),
+			sampleResult({ viewport: { name: 'pc', width: 1280 }, root: pcRoot }),
+		]);
+
+		expect(result.blocks[0]!.items).toStrictEqual([
+			[{ name: 'title-h2', data: { titleH2: 'pc' } }],
+		]);
+	});
+
+	test('該当する名前のビューポートが無い場合は幅最大のエントリにフォールバックする', () => {
+		const wideRoot = sampleBlock({
+			children: [
+				sampleBlock({
+					layoutType: 'vertical-stack',
+					confidence: 0.8,
+					children: [heading('wide')],
+				}),
+			],
+		});
+		const narrowRoot = sampleBlock({
+			children: [
+				sampleBlock({
+					layoutType: 'vertical-stack',
+					confidence: 0.8,
+					children: [heading('narrow')],
+				}),
+			],
+		});
+		const result = layoutToBlockData([
+			sampleResult({ viewport: { name: 'desktop', width: 1440 }, root: wideRoot }),
+			sampleResult({ viewport: { name: 'mobile', width: 390 }, root: narrowRoot }),
+		]);
+
+		expect(result.blocks[0]!.items).toStrictEqual([
+			[{ name: 'title-h2', data: { titleH2: 'wide' } }],
+		]);
+	});
+});

--- a/packages/@d-zero/site-migrator/src/page-extractor/layout-to-block-data.ts
+++ b/packages/@d-zero/site-migrator/src/page-extractor/layout-to-block-data.ts
@@ -1,0 +1,297 @@
+import type { BlockData, BlockItem, ContainerProps } from '@burger-editor/core';
+import type { LayoutAnalysisResult, LayoutBlock } from '@d-zero/anatomist/types';
+
+import { classifyBlockItem, wysiwygItem } from './classify-block-item.js';
+
+export type BlockFallbackReason =
+	'viewport-mismatch' | 'malformed-row-sizes' | 'low-confidence';
+
+export interface LayoutToBlockDataOptions {
+	/** 構造判定の主とするビューポート名。既定 'pc'。見つからなければ幅最大のエントリにフォールバック。 */
+	primaryViewportName?: string;
+}
+
+export interface LayoutToBlockDataResult {
+	blocks: BlockData[];
+	/**
+	 * ブロック単位の構造フォールバックの記録（#976のレポート用）。セル単位の`classifyBlockItem`の
+	 * 結果としての`wysiwyg`（正常な分類結果）はここには含まれない。
+	 */
+	fallbacks: { blockIndex: number; reason: BlockFallbackReason }[];
+}
+
+const DEFAULT_PRIMARY_VIEWPORT_NAME = 'pc';
+
+/**
+ * コンテナ系`layoutType`（vertical-stack/horizontal-row/simple-grid/complex-grid/float-wrap）
+ * に対する`confidence`の下限。現行anatomist実装ではマッチ時confidenceは`0.6`(complex-grid)〜
+ * `1`(table)、非マッチ(`unknown`)は常に`0`のため、この閾値は実質的に発火しない防御的な
+ * 二重チェック（将来のdetector変更に備えた保険）。`leaf`には適用しない（`leaf`のconfidenceは
+ * 常に0固定であり、この閾値の対象外 — `classify-block-item.ts`のJSDoc参照）。
+ */
+const DEFAULT_MIN_CONTAINER_CONFIDENCE = 0.5;
+
+/**
+ * ブロックの見た目上の種別名は未確定（#975/#976で命名確定するまでのプレースホルダー）。
+ */
+const MIGRATED_BLOCK_NAME = 'migrated';
+
+/**
+ * 同一URLの複数ビューポート分 `LayoutAnalysisResult[]` を受け取り、PCビューポートを主として
+ * ビューポート整合性判断・深さ圧縮・行列変換・containerPropsマッピングを行い `BlockData[]` を
+ * 返す純粋関数。
+ *
+ * 処理の流れ:
+ * 1. `primaryViewportName`（既定`'pc'`）に一致する`viewport.name`のエントリを主とする。
+ *    無ければ幅最大のエントリにフォールバック。`primary.root === null`または`results`が
+ *    空なら`{blocks:[], fallbacks:[]}`を返す（main未検出はページ全体フォールバック=#976の
+ *    責務であり、ここでは単に「0件」を返す）。
+ * 2. `primary.root.children`（depth-1候補）をインデックスで走査し、他ビューポートの同一
+ *    インデックスノードと`children.length`を比較する（ビューポートが1つしかなければこの
+ *    チェックはスキップする）。不一致ならそのブロックを`wysiwyg`単一アイテムに倒す。
+ * 3. `layoutType`→`ContainerProps`写像と`signals.rowSizes`を使った行列再構築
+ *    （{@link resolveItemGrid}）。不正な形状・低信頼度ならそのブロックを`wysiwyg`単一
+ *    アイテムに倒す。
+ * 4. 深さ圧縮: 決定した行×列の各セル（depth-2ノード）を、`children`を一切見ずそのまま
+ *    {@link classifyBlockItem} に渡す。深さ3以降の`layoutType`情報は`classifyBlockItem`が
+ *    `innerHTML`文字列のみを見ることで自動的に破棄される。
+ * @param results
+ * @param options
+ * @example
+ * ```ts
+ * const { blocks, fallbacks } = layoutToBlockData([
+ *   { url: 'https://example.com/', viewport: { name: 'pc', width: 1280 }, mainSelector: 'main', root },
+ * ]);
+ * // blocks: BlockData[]（BurgerEditorへそのまま渡せる形）
+ * // fallbacks: [{ blockIndex: 2, reason: 'viewport-mismatch' }, ...]（構造フォールバックの記録）
+ * ```
+ */
+export function layoutToBlockData(
+	results: readonly LayoutAnalysisResult[],
+	options: LayoutToBlockDataOptions = {},
+): LayoutToBlockDataResult {
+	const primaryViewportName =
+		options.primaryViewportName ?? DEFAULT_PRIMARY_VIEWPORT_NAME;
+	const primary = selectPrimary(results, primaryViewportName);
+	if (!primary || primary.root === null) {
+		return { blocks: [], fallbacks: [] };
+	}
+
+	const otherRoots = results
+		.filter((result) => result !== primary)
+		.map((result) => result.root);
+	const checkViewportConsistency = otherRoots.length > 0;
+
+	const blocks: BlockData[] = [];
+	const fallbacks: { blockIndex: number; reason: BlockFallbackReason }[] = [];
+
+	for (const [index, node] of primary.root.children.entries()) {
+		if (checkViewportConsistency && !childCountMatches(node, index, otherRoots)) {
+			blocks.push(wysiwygBlockData(node));
+			fallbacks.push({ blockIndex: index, reason: 'viewport-mismatch' });
+			continue;
+		}
+
+		const resolved = resolveItemGrid(node, DEFAULT_MIN_CONTAINER_CONFIDENCE);
+		if (!resolved.ok) {
+			blocks.push(wysiwygBlockData(node));
+			fallbacks.push({ blockIndex: index, reason: resolved.reason });
+			continue;
+		}
+
+		blocks.push({
+			name: MIGRATED_BLOCK_NAME,
+			containerProps: resolved.containerProps,
+			items: resolved.rows.map((row) =>
+				row.map((cell) => toBlockItem(classifyBlockItem(cell))),
+			),
+		});
+	}
+
+	return { blocks, fallbacks };
+}
+
+/**
+ * @param results
+ * @param primaryViewportName
+ */
+function selectPrimary(
+	results: readonly LayoutAnalysisResult[],
+	primaryViewportName: string,
+): LayoutAnalysisResult | undefined {
+	if (results.length === 0) {
+		return undefined;
+	}
+	const named = results.find((result) => result.viewport.name === primaryViewportName);
+	if (named) {
+		return named;
+	}
+	let widest = results[0]!;
+	for (const result of results) {
+		if (result.viewport.width > widest.viewport.width) {
+			widest = result;
+		}
+	}
+	return widest;
+}
+
+/**
+ * `primary`側の depth-1 ノード（`node`）自身の子要素数が、他ビューポートの同一インデックス
+ * ノードと一致するかを判定する。対応ノードが存在しない場合（`root`がnull、または
+ * `children[index]`が無い）も不一致として扱う（安全側）。
+ * @param node
+ * @param index
+ * @param otherRoots
+ */
+function childCountMatches(
+	node: LayoutBlock,
+	index: number,
+	otherRoots: readonly (LayoutBlock | null)[],
+): boolean {
+	const expected = node.children.length;
+	return otherRoots.every((otherRoot) => {
+		const otherNode = otherRoot?.children[index];
+		return otherNode !== undefined && otherNode.children.length === expected;
+	});
+}
+
+type ResolveItemGridResult =
+	| {
+			ok: true;
+			containerProps: Partial<ContainerProps>;
+			rows: readonly (readonly LayoutBlock[])[];
+	  }
+	| { ok: false; reason: BlockFallbackReason };
+
+/**
+ * 1つの depth-1 ノードについて、`layoutType`から`ContainerProps`を決定し、`children`を
+ * 行×列（`BlockItem`の元になる`LayoutBlock`の2次元配列）に並べ替える。Issue記載の対応表:
+ *
+ * - `vertical-stack` → `{type:'grid', columns:1}`、子はN行1列
+ * - `horizontal-row` → `{type:'inline'}`、子は1行N列
+ * - `simple-grid`/`complex-grid` → `{type:'grid', columns: 行あたり最大列数}`。
+ *   `signals.rowSizes`を検証した上で使用。不正な形状なら`ok:false`
+ * - `float-wrap` → `{type:'float', float: signalsから読めれば反映、読めなければnull}`
+ * - `table`/`unknown`/`leaf` → `{type:'grid', columns:1}`（単一item、1行1列）
+ * @param node
+ * @param minConfidence
+ */
+function resolveItemGrid(
+	node: LayoutBlock,
+	minConfidence: number,
+): ResolveItemGridResult {
+	switch (node.layoutType) {
+		case 'vertical-stack': {
+			if (node.confidence < minConfidence) {
+				return { ok: false, reason: 'low-confidence' };
+			}
+			return {
+				ok: true,
+				containerProps: { type: 'grid', columns: 1 },
+				rows: node.children.map((child) => [child]),
+			};
+		}
+		case 'horizontal-row': {
+			if (node.confidence < minConfidence) {
+				return { ok: false, reason: 'low-confidence' };
+			}
+			return { ok: true, containerProps: { type: 'inline' }, rows: [node.children] };
+		}
+		case 'simple-grid':
+		case 'complex-grid': {
+			if (node.confidence < minConfidence) {
+				return { ok: false, reason: 'low-confidence' };
+			}
+			const rows = buildRowsFromRowSizes(node.children, node.signals.rowSizes);
+			if (!rows) {
+				return { ok: false, reason: 'malformed-row-sizes' };
+			}
+			const columns = Math.max(...rows.map((row) => row.length));
+			return { ok: true, containerProps: { type: 'grid', columns }, rows };
+		}
+		case 'float-wrap': {
+			if (node.confidence < minConfidence) {
+				return { ok: false, reason: 'low-confidence' };
+			}
+			return {
+				ok: true,
+				containerProps: { type: 'float', float: readFloatDirection(node.signals) },
+				rows: [node.children],
+			};
+		}
+		// 'table' / 'unknown' / 'leaf' はここに落ちる（単一item、1行1列）。
+		default: {
+			return { ok: true, containerProps: { type: 'grid', columns: 1 }, rows: [[node]] };
+		}
+	}
+}
+
+/**
+ * `children`を先頭から`rowSizes`の各要素数ずつ順番に区切って行を再構築する。`signals`は
+ * anatomist側で型付けされていない`Record<string, unknown>`（デバッグ用の生エビデンスであり
+ * 公開契約ではない）であるため、`rowSizes`の形状を実行時に検証する:
+ * 空でない配列であること、各要素が正の整数であること、合計が`children.length`と一致すること。
+ * いずれかを満たさない場合は`undefined`を返し、呼び出し側が低信頼度としてブロックを
+ * `wysiwyg`にフォールバックする（空配列を許すと`resolveItemGrid`の`Math.max(...rows.map(...))`
+ * が`-Infinity`になり不正な`columns`が生成されるため、ここで弾く）。
+ * @param children
+ * @param rowSizesValue
+ */
+function buildRowsFromRowSizes(
+	children: readonly LayoutBlock[],
+	rowSizesValue: unknown,
+): readonly (readonly LayoutBlock[])[] | undefined {
+	if (!Array.isArray(rowSizesValue) || rowSizesValue.length === 0) {
+		return undefined;
+	}
+	const rowSizes = rowSizesValue as unknown[];
+	const isValidShape = rowSizes.every(
+		(size) => typeof size === 'number' && Number.isInteger(size) && size > 0,
+	);
+	if (!isValidShape) {
+		return undefined;
+	}
+	const total = (rowSizes as number[]).reduce((sum, size) => sum + size, 0);
+	if (total !== children.length) {
+		return undefined;
+	}
+
+	const rows: LayoutBlock[][] = [];
+	let cursor = 0;
+	for (const size of rowSizes as number[]) {
+		rows.push(children.slice(cursor, cursor + size));
+		cursor += size;
+	}
+	return rows;
+}
+
+/**
+ * `detect-float-wrap-pattern.ts`の現状の`signals`にはfloat方向（start/end）を示すキーが
+ * 存在しないため、実際には常に`null`を返す想定。将来anatomist側が対応した際に自動的に
+ * 機能するようここで読み取りを試みる。
+ * @param signals
+ */
+function readFloatDirection(signals: Record<string, unknown>): 'start' | 'end' | null {
+	const value = signals.float ?? signals.floatDirection;
+	return value === 'start' || value === 'end' ? value : null;
+}
+
+/**
+ * ビューポート不一致・`rowSizes`不正形状・低信頼度で、depth-1ノード全体を単一アイテムの
+ * `wysiwyg`に倒す。
+ * @param node
+ */
+function wysiwygBlockData(node: LayoutBlock): BlockData {
+	return {
+		name: MIGRATED_BLOCK_NAME,
+		containerProps: { type: 'grid', columns: 1 },
+		items: [[toBlockItem(wysiwygItem(node))]],
+	};
+}
+
+/**
+ * @param classified
+ */
+function toBlockItem(classified: ReturnType<typeof classifyBlockItem>): BlockItem {
+	return { name: classified.name, data: classified.data };
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1718,6 +1718,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@d-zero/site-migrator@workspace:packages/@d-zero/site-migrator"
   dependencies:
+    "@burger-editor/core": "npm:4.0.0-alpha.65"
     "@d-zero/anatomist": "npm:0.2.0"
     "@d-zero/dealer": "npm:1.10.1"
     "@d-zero/shared": "npm:0.22.2"


### PR DESCRIPTION
## Summary

- Add `classifyBlockItem` (`src/page-extractor/classify-block-item.ts`) — a pure function that
  heuristically classifies a single anatomist `LayoutBlock` into a BurgerEditor item
  (`image`/`title-h2`/`title-h3`/`youtube`/`google-maps`/`download-file`/`button`/`table`/`wysiwyg`)
  based only on `tagName`/`classList`/`innerHTML`/`layoutType`
- Add `layoutToBlockData` (`src/page-extractor/layout-to-block-data.ts`) — a pure function that
  converts multiple viewports' `LayoutAnalysisResult[]` for one URL into `BlockData[]`, handling
  viewport consistency checks (mismatched child counts fall back to `wysiwyg`), depth compression
  (only 2 levels — block > row×column > item — are kept; deeper nesting is handed to
  `classifyBlockItem` as opaque `innerHTML`), `layoutType` → `ContainerProps` mapping, and
  `signals.rowSizes`-based row reconstruction for grid layouts. Returns
  `{ blocks, fallbacks }`, where `fallbacks` records the reason (`viewport-mismatch` /
  `malformed-row-sizes` / `low-confidence`) for each block-level fallback
- Add `@burger-editor/core@4.0.0-alpha.65` to `dependencies` (types only)

## Known limitation

anatomist's `LayoutBlock`/`RawLayoutNode` does not capture element attributes (`href`/`src`/
`srcset`/`alt`/`width`/`height`, etc.), and its collapse logic discards wrapper elements such as
`<picture>`/`<figure>`, leaving only the innermost `<img>` (a void element with empty
`innerHTML`). As a result, on real-world data the `image`/`youtube`/`google-maps`/`download-file`/
`button.link` classifications almost always fall back to `wysiwyg` today. This is implemented as
specified regardless, so it activates automatically once anatomist gains attribute capture (to be
tracked as a follow-up in the `tools` repo).

## Scope

Second sub-issue of #977 (BurgerEditor block conversion pipeline), consuming #973's
`resolvePageLayouts` output. Scope is limited to the two new pure functions plus the dependency
addition — like `resolvePageLayouts`, they are not exported from `src/index.ts` yet; wiring into
the CLI/`extractPages` pipeline, actual `data-bge-*` HTML generation, and round-trip validation are
deferred to #975/#976/#980.

Closes #974

## Test plan

- [x] `yarn build`
- [x] `yarn test` (210 tests, all passing)
- [x] `yarn lint` (0 errors)
