### PR TITLE
feat(site-migrator): integrate BurgerEditor block conversion into extractPages

### DIFF
--- a/packages/@d-zero/site-migrator/README.md
+++ b/packages/@d-zero/site-migrator/README.md
@@ -1,6 +1,6 @@
 # `@d-zero/site-migrator`
 
-`.nitpicker` アーカイブを入力とするウェブサイト移植ツールキット。サブリソースのローカル DL、ページ HTML のレイアウト剥がし、`.nitpicker` DB のページメタと採番した整数 id を YAML frontmatter として prepend する CLI、同一オリジン参照を後段パイプライン向けに書き換えるリライタ、および周辺ユーティリティ関数群を提供する。
+`.nitpicker` アーカイブを入力とするウェブサイト移植ツールキット。サブリソースのローカル DL、ページ HTML のレイアウト剥がしと BurgerEditor ブロックへの変換、`.nitpicker` DB のページメタと採番した整数 id を YAML frontmatter として prepend する CLI、同一オリジン参照を後段パイプライン向けに書き換えるリライタ、および周辺ユーティリティ関数群を提供する。
 
 ## Installation
 
@@ -11,15 +11,17 @@ yarn add @d-zero/site-migrator
 ## CLI
 
 ```sh
-npx dz-migrate <archive.nitpicker> -o <htdocs-dir> [--limit <n>] [--extract-limit <n>]
+npx dz-migrate <archive.nitpicker> -o <htdocs-dir> --content-class <name> [--layout-json <path>] [--limit <n>] [--extract-limit <n>]
 ```
 
 - `<archive.nitpicker>` — [nitpicker](https://github.com/d-zero-dev/nitpicker) で生成済みのアーカイブファイル
 - `-o, --output <htdocs-dir>` — 出力先。URL の pathname をそのままミラーする（例: `https://example.com/img/a.png` → `<htdocs-dir>/img/a.png`、`https://example.com/about/` → `<htdocs-dir>/about/index.html`）
+- `--content-class <name>` — **必須**。BurgerEditor の `editableArea` セレクタに対応させるクラス名。生成したブロック群を埋め込む既存 main 要素自身の `classList` に追加する（移行先サイトの BurgerEditor 設定に依存する値のため既定値は無い）
+- `--layout-json <path>` — 事前生成済みの anatomist レイアウト解析 JSONL（1 ファイルで対象 URL 全件分）。省略時は全ページをライブ解析する
 - `--limit <n>` — 並列 DL 数（デフォルト 10）
-- `--extract-limit <n>` — 並列ページ抽出数（デフォルト 10）
+- `--extract-limit <n>` — 並列ページ抽出数（デフォルト 10）。ライブレイアウト解析の並列数もこれを共用する
 
-リソースは fetch で DL、ページ HTML はアーカイブ内のスナップショットを読み、`extractMainContent` でレイアウト共通部分を剥がし、`assignPageIds` で URL → 整数 id の写像を組み立てて `.nitpicker` DB のページメタと併せて `formatFrontmatter` が生成する `---\n…\n---\n` YAML ブロックを先頭に prepend、本文中の同一オリジン参照を `rewritePageRefs` が書き換えてから `.html` として書き出す。
+リソースは fetch で DL、ページ HTML はアーカイブ内のスナップショットを読み、`extractMainContent` でレイアウト共通部分を剥がし、そのページのレイアウトを BurgerEditor ブロックへ変換して既存 main 要素へ埋め込み（後述）、`assignPageIds` で URL → 整数 id の写像を組み立てて `.nitpicker` DB のページメタと併せて `formatFrontmatter` が生成する `---\n…\n---\n` YAML ブロックを先頭に prepend、本文中の同一オリジン参照を `rewritePageRefs` が書き換えてから `.html` として書き出す。
 
 ## Programmatic API
 
@@ -128,14 +130,38 @@ import {
 
 `formatFrontmatter` は後続の scaffold パイプラインがそのまま消費できる YAML を生成する。og.\* / twitter.\* は nested map で、サブオブジェクト全体が空なら親キーも省略される。`twitter.url` は DB に対応カラムがないため型・出力ともに非対応（`og.url` で代替する慣習に従う）。
 
-`extractPages` は `extractMainContent` と `getFrontmatter` を並列実行し、生成した YAML ブロックを抽出 HTML の先頭に prepend してから書き出す。整数 id は常に付与されるので「DB 行なし」のページでも `---\nid: <number>\n---\n` ブロックは出る。`getFrontmatter` が例外を投げた場合は fail-soft で id-only frontmatter と本文を書き出し、`onResult` の outcome に `metaError` を載せて警告する（`migrate()` レポートでは `pagesMetaFailed` として集計される）。
+`extractPages` は `extractMainContent` と `getFrontmatter` を並列実行し、main 要素が見つかったページには続けて BurgerEditor ブロック変換パイプライン（後述）を適用したうえで、生成した YAML ブロックを本文の先頭に prepend してから書き出す。整数 id は常に付与されるので「DB 行なし」のページでも `---\nid: <number>\n---\n` ブロックは出る。`getFrontmatter` が例外を投げた場合は fail-soft で id-only frontmatter と本文を書き出し、`onResult` の outcome に `metaError` を載せて警告する（`migrate()` レポートでは `pagesMetaFailed` として集計される）。
 
-### レイアウト → BlockData 変換（`classifyBlockItem` / `layoutToBlockData`）
+### BurgerEditor ブロック変換パイプライン（`dz-migrate` のデフォルト動作）
 
-既存サイトを BurgerEditor ブロックへ移行するパイプライン（親 Issue #977）向けの純関数群。`resolvePageLayouts`（#973 実装済み）と同様、現時点ではパイプライン全体への統合前のため `index.ts` からは export していない（`src/page-extractor/classify-block-item.ts` / `layout-to-block-data.ts` を直接 import する内部 API）。統合とパイプライン公開範囲の判断は #976 で行う。
+`.nitpicker` アーカイブベースのレイアウト剥がしだけでは `data-bge-*` マーカーが無く、BurgerEditor 上では「1 個の wysiwyg フォールバックブロック」としてしか扱えない。site-migrator の存在意義は既存サイトを BurgerEditor で編集可能なブロック構造に変換することなので、このブロック変換はオプトインフラグではなく `extractPages` / `dz-migrate` の既定動作になっている（`--content-class` は必須オプションだが、指定すれば必ず変換が走る）。
 
-- `classifyBlockItem(block: LayoutBlock): ClassifiedBlockItem` — anatomist の `LayoutBlock` 1 個を `image`/`title-h2`/`title-h3`/`youtube`/`google-maps`/`download-file`/`button`/`table`/`wysiwyg` の BurgerEditor アイテム種別へヒューリスティック分類する。`children`/`boundingBox`/`confidence` は見ない純関数。
-- `layoutToBlockData(results: LayoutAnalysisResult[], options?): { blocks: BlockData[], fallbacks: {blockIndex, reason}[] }` — 同一 URL の複数ビューポート分の解析結果を受け取り、PC ビューポートを主として深さ圧縮・行列変換・`containerProps` マッピングを行う純関数。`fallbacks` はブロック単位の構造フォールバック（`viewport-mismatch` / `malformed-row-sizes` / `low-confidence`）の理由を記録し、#976 のレポート拡張にそのまま使える。
+処理は次の要素で構成される（いずれも `src/page-extractor/` 配下、統合前は内部 API だったが `extractPages` に組み込まれた現在も `index.ts` からは export していない）:
+
+| 関数                 | 概要                                                                                                                                                                            |
+| -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `resolvePageLayouts` | `--layout-json` の事前生成 JSONL を優先し、無ければ Puppeteer + `@d-zero/anatomist` でライブ解析する                                                                            |
+| `classifyBlockItem`  | anatomist の `LayoutBlock` 1 個を `image`/`title-h2`/`title-h3`/`youtube`/`google-maps`/`download-file`/`button`/`table`/`wysiwyg` へヒューリスティック分類する純関数           |
+| `layoutToBlockData`  | 複数ビューポート分の解析結果から `BlockData[]` を組み立てる純関数。ブロック単位の低信頼度は個別に `wysiwyg` へ倒し `fallbacks` に記録する                                       |
+| `renderBlocks`       | `@burger-editor/core` の公式 `render()` で `BlockData[]` を `data-bge-*` 付き HTML へ変換する                                                                                   |
+| `mergeMainContent`   | `renderBlocks` のラッパー `<div>` の中身だけを既存 main 要素の子要素として差し替え、`--content-class` を main 要素自身の `classList` に追加する（新規ラッパー要素は追加しない） |
+| `isMainConsistent`   | anatomist の `mainSelector` と `extractMainContent` がマッチした要素の `outerHTML` を比較する簡易整合性チェック                                                                 |
+| `downloadBlockFiles` | 生成ブロック内の `download-file` アイテムの `path` を集めて `downloadResources` へ二重 DL を避けつつ追加投入し、実ファイルサイズを `size`/`formatedSize` に反映する             |
+
+`extractPages` はページごとに以下の順で処理する:
+
+1. `getPageHtml` + `extractMainContent` + `getFrontmatter` を全ページ分並列実行し、main が見つかったページ（ブロック変換対象）と見つからなかったページ（`outcome: 'fallback'`）を仕分ける。
+2. ブロック変換対象の全 URL をまとめて **1 回**の `resolvePageLayouts` 呼び出しに渡す（ページごとに呼ぶと Puppeteer ブラウザをページ数だけ起動することになり実運用サイト規模では致命的に遅くなるため）。
+3. ページごとに `isMainConsistent` → `layoutToBlockData` → `downloadBlockFiles`（バッチ） → `renderBlocks` → `mergeMainContent` → `rewritePageRefs` → frontmatter 付与 → 書き出し、という順で処理する。
+
+#### ブロック単位フォールバックとページ単位フォールバックの区別
+
+- **ブロック単位**（致命的ではない）: `layoutToBlockData` が低信頼度・ビューポート不一致・`rowSizes` 不正形状と判断した個別ブロックだけを `wysiwyg` 単一アイテムに倒す。閾値は設けない。他の高信頼度ブロックはそのまま出力し、ページ全体は諦めない。この場合 `ExtractPageResult.blockConversion` は `'partial'` になる。
+- **ページ単位**（致命的）: 以下のいずれかに該当する場合のみ、そのページ全体を `data-bge-*` マーカー無しのプレーンな元の完全な HTML として出力する（`blockConversion: 'fallback'`、原因は `blockConversionError`）。**品質判断（低信頼度ブロックが多い等）によるページ全体フォールバックは行わない**:
+  - `resolvePageLayouts` がそのページについて完全に失敗した（ライブ URL 到達不可等）
+  - `isMainConsistent` が anatomist の `mainSelector` と `extractMainContent` のマッチ不一致と判定した（簡易判定。厳密な整合化は将来の課題）
+  - `layoutToBlockData` が空の `blocks` を返した（anatomist 側で `root` が見つからなかった）
+  - `renderBlocks` または `mergeMainContent` が例外を投げた
 
 #### 既知の制限（重要）
 
@@ -145,15 +171,14 @@ anatomist の `LayoutBlock`/`RawLayoutNode` は要素の属性（`href` / `src` 
 
 - `confidence` はコンテナ系 `layoutType`（vertical-stack/horizontal-row/simple-grid/complex-grid/float-wrap）にのみ `0.5` 閾値で二重チェックする。`leaf` の `confidence` は anatomist 側で常に `0` 固定なので、`classifyBlockItem` はこの値を一切参照しない（参照すると分類対象を全て `wysiwyg` に落とす自己矛盾になる）。
 - 深さ圧縮（`BlockData.items` は「ブロック → 行×列 → item」の 2 階層まで）は、depth-2 ノードの `children` を一切読まず `classifyBlockItem` に丸投げすることで実現している。`classifyBlockItem` が `innerHTML` 文字列のみを見るため、depth-3 以降の `layoutType` 情報は自動的に破棄される。
-- `BlockData.name` は固定値 `'migrated'`（ブロックの見た目上の種別名は #975/#976 で命名確定するまでのプレースホルダー）。
-- `download-file` の `size`/`formatedSize` は空文字列のプレースホルダー。実 DL と実サイズの反映は既存の `downloadResources` と連携させて #976 で行う（`classifyBlockItem` はネットワーク I/O を一切行わない）。
+- `BlockData.name` は固定値 `'migrated'`（ブロックの見た目上の種別名は未確定のプレースホルダー）。
+- `render()` は内部で `document.createElement` / `new Range()` 等の DOM API に依存するため、初回呼び出し時のみ jsdom を起動して `globalThis` へ反映する（既に DOM 環境が存在する場合は何もしない）。
+- 生成したブロック内（wysiwyg の `<a href>`、image の `path` 等）の URL 自体は `rewritePageRefs` の対象外（既存 main 要素の外側にあった参照のみが書き換え対象）。ブロック内 URL への適用は将来の課題として切り出されている。
 
-### BurgerEditor ブロックの HTML 化（`renderBlocks`）
+### 出力先ライブラリ連携（`downloadBlockFiles`）
 
-`layoutToBlockData` が返す `BlockData[]`（1 ページ分）を、BurgerEditor 公式の `@burger-editor/core` `render()` API を使って `data-bge-*` 付き HTML へ変換する純関数群。マークアップ仕様を自前で再実装せず、公式 API と `@burger-editor/blocks` の既定アイテムカタログ（カスタマイズ不可）にそのまま委譲する。`render()` は内部で `document.createElement` / `new Range()` 等の DOM API に依存するため、初回呼び出し時のみ jsdom を起動して `globalThis` へ反映する（既に DOM 環境が存在する場合は何もしない）。`classifyBlockItem` / `layoutToBlockData` 同様、統合前の内部 API のため `index.ts` からは export していない（`src/page-extractor/render-blocks.ts` を直接 import する）。統合先（`extractMainContent` 後段への差し込み、ページ単位のフォールバック判断）は #976 で行う。
-
-- `renderBlocks(blocks: BlockData[], options: { contentClass: string }): Promise<string>` — 1 ブロックずつ `render()` へ渡して HTML 要素を生成・連結し、`contentClass` を持つラッパー `<div>` で囲んだ 1 ページ分の HTML 文字列を返す。
+`downloadBlockFiles` は `migrate()` が事前に収集した通常のリソース URL 集合（`knownResourceUrls`）と重複しない `download-file` アイテムの `path` だけを `downloadResources` へ追加投入する（fetch 処理そのものは再実装しない）。ダウンロード後（または既にカバー済みでスキップした場合も含めて）実ファイルサイズを `stat` で読み、`size`/`formatedSize` を実測値で書き戻す。同一ファイルが複数ページ・複数アイテムから参照されていてもダウンロードは 1 回で済ませる。
 
 ### 設計上の注意
 
-`extractMainContent` / `rewriteAssetRefs` は parse5 を内部で使う純関数、`getFrontmatter` は `@nitpicker/query` の DB 読み出しに依存する。両者の責務分離は `src/html/` (parse5) と `src/archive/` (`@nitpicker/query`) のディレクトリ構造で表現している。
+`extractMainContent` / `rewriteAssetRefs` / `mergeMainContent` は parse5 を内部で使う純関数、`getFrontmatter` は `@nitpicker/query` の DB 読み出しに依存する。両者の責務分離は `src/html/` (parse5) と `src/archive/` (`@nitpicker/query`) のディレクトリ構造で表現している。

--- a/packages/@d-zero/site-migrator/src/cli.ts
+++ b/packages/@d-zero/site-migrator/src/cli.ts
@@ -4,20 +4,29 @@ import { parseArgs } from 'node:util';
 import { migrate } from './migrate.js';
 
 const USAGE = `Usage:
-  dz-migrate <archive.nitpicker> -o <htdocs-dir> [--limit <n>] [--extract-limit <n>]
+  dz-migrate <archive.nitpicker> -o <htdocs-dir> --content-class <name> [--layout-json <path>] [--limit <n>] [--extract-limit <n>]
 
 Downloads sub-resources from the archive and, for each internal page, strips
 the shared layout, assigns a stable integer id, prepends a YAML frontmatter
-block (id + DB-sourced meta), and rewrites same-origin URL references inside
-the body (asset URLs → root-relative paths; <a href> / <form action> → the
-{{<id>}} template token consumed by the downstream scaffold pipeline). Output
-files are intermediate artifacts, not for direct browser rendering.
+block (id + DB-sourced meta), converts the page's layout into BurgerEditor
+blocks (data-bge-* markup embedded into the existing main element — see
+--content-class), and rewrites same-origin URL references inside the body
+(asset URLs → root-relative paths; <a href> / <form action> → the {{<id>}}
+template token consumed by the downstream scaffold pipeline). Output files are
+intermediate artifacts, not for direct browser rendering.
 
 Options:
   -o, --output <htdocs-dir>      Output destination. URL pathnames are mirrored verbatim
                                  for both downloaded resources and extracted page HTML.
+  --content-class <name>          Required. Class name added to each page's existing main
+                                 element (matching BurgerEditor's editableArea selector for
+                                 this project). No default — a wrong guess would silently
+                                 produce output BurgerEditor cannot recognise.
+  --layout-json <path>            Pre-generated anatomist layout analysis JSONL (one file for
+                                 every URL). URLs absent from it fall back to live analysis.
   --limit <n>                    Concurrent resource download limit (default: 10).
-  --extract-limit <n>            Concurrent page extraction limit (default: 10).
+  --extract-limit <n>            Concurrent page extraction limit (default: 10). Also shared
+                                 by live layout analysis concurrency.
   -h, --help                     Show this help message.
 `;
 
@@ -34,6 +43,8 @@ async function main(argv: readonly string[]): Promise<number> {
 			strict: true,
 			options: {
 				output: { type: 'string', short: 'o' },
+				'content-class': { type: 'string' },
+				'layout-json': { type: 'string' },
 				limit: { type: 'string' },
 				'extract-limit': { type: 'string' },
 				help: { type: 'boolean', short: 'h', default: false },
@@ -67,6 +78,13 @@ async function main(argv: readonly string[]): Promise<number> {
 		return 2;
 	}
 
+	const contentClass = parsed.values['content-class'];
+	if (contentClass === undefined) {
+		process.stderr.write(`Error: --content-class is required\n\n${USAGE}`);
+		return 2;
+	}
+	const layoutJsonPath = parsed.values['layout-json'];
+
 	const downloadLimit = parsePositiveInt(parsed.values.limit, '--limit');
 	if (downloadLimit instanceof Error) {
 		process.stderr.write(`Error: ${downloadLimit.message}\n`);
@@ -89,6 +107,8 @@ async function main(argv: readonly string[]): Promise<number> {
 		const report = await migrate({
 			archivePath,
 			outputDir,
+			contentClass,
+			layoutJsonPath,
 			downloadLimit,
 			extractLimit,
 			signal: controller.signal,
@@ -102,7 +122,13 @@ async function main(argv: readonly string[]): Promise<number> {
 			onPage: (event) => {
 				switch (event.outcome) {
 					case 'extracted': {
-						process.stdout.write(`page: ${event.url} (${event.matchedBy})\n`);
+						const blockNote =
+							event.blockConversion === 'fallback'
+								? `fallback — ${event.blockConversionError?.message ?? 'unknown error'}`
+								: event.blockConversion;
+						process.stdout.write(
+							`page: ${event.url} (${event.matchedBy}, blocks: ${blockNote})\n`,
+						);
 						break;
 					}
 					case 'fallback': {
@@ -145,6 +171,7 @@ async function main(argv: readonly string[]): Promise<number> {
 		process.stdout.write(
 			`\nResources: ${report.resourcesSaved} saved, ${report.resourcesFailed} failed, ${resourcesSkipped} skipped (out of ${report.totalResources}).\n` +
 				`Pages: ${report.pagesExtracted} extracted, ${report.pagesFallback} fallback, ${report.pagesMissing} missing, ${report.pagesFailed} failed, ${pagesSkipped} skipped (out of ${report.totalPages}).\n` +
+				`Blocks: ${report.pagesBlockConverted} converted, ${report.pagesBlockPartial} partial, ${report.pagesBlockConversionFailed} fallback (out of ${report.pagesExtracted} extracted).\n` +
 				`Soft errors (body still written): ${report.pagesRewriteFailed} rewrite, ${report.pagesMetaFailed} meta.\n`,
 		);
 		if (controller.signal.aborted || resourcesSkipped > 0 || pagesSkipped > 0) {

--- a/packages/@d-zero/site-migrator/src/html/extract-main-content.ts
+++ b/packages/@d-zero/site-migrator/src/html/extract-main-content.ts
@@ -6,12 +6,7 @@ type Element = DefaultTreeAdapterMap['element'];
 type Node = DefaultTreeAdapterMap['childNode'];
 
 export type ExtractMainCriterion =
-	| 'class:main'
-	| 'class:content'
-	| 'tag:main'
-	| 'role:main'
-	| 'id:main'
-	| 'id:content';
+	'class:main' | 'class:content' | 'tag:main' | 'role:main' | 'id:main' | 'id:content';
 
 export interface ExtractMainResult {
 	/**

--- a/packages/@d-zero/site-migrator/src/html/merge-main-content.spec.ts
+++ b/packages/@d-zero/site-migrator/src/html/merge-main-content.spec.ts
@@ -1,0 +1,79 @@
+import { describe, expect, test } from 'vitest';
+
+import { mergeMainContent } from './merge-main-content.js';
+
+describe('mergeMainContent', () => {
+	test('既存main要素の子要素をラッパーの中身で置き換え、contentClassをmain自身に追加する', () => {
+		const result = mergeMainContent({
+			mainHtml: '<main><p>old</p></main>',
+			wrapperHtml: '<div class="js-bge-content"><div data-bge-name="a">new</div></div>',
+			contentClass: 'js-bge-content',
+		});
+
+		expect(result).toBe(
+			'<main class="js-bge-content"><div data-bge-name="a">new</div></main>',
+		);
+	});
+
+	test('既存main要素が既にclassを持つ場合はトークンとして追加する（既存クラスは保持）', () => {
+		const result = mergeMainContent({
+			mainHtml: '<main class="l-main"><p>old</p></main>',
+			wrapperHtml: '<div class="js-bge-content"><p>new</p></div>',
+			contentClass: 'js-bge-content',
+		});
+
+		expect(result).toBe('<main class="l-main js-bge-content"><p>new</p></main>');
+	});
+
+	test('main要素が既にcontentClassを含む場合は重複追加しない', () => {
+		const result = mergeMainContent({
+			mainHtml: '<main class="l-main js-bge-content"><p>old</p></main>',
+			wrapperHtml: '<div class="js-bge-content"><p>new</p></div>',
+			contentClass: 'js-bge-content',
+		});
+
+		expect(result).toBe('<main class="l-main js-bge-content"><p>new</p></main>');
+	});
+
+	test('ラッパーが空（ブロック0件）でも既存main子要素を空に置き換える', () => {
+		const result = mergeMainContent({
+			mainHtml: '<main><p>old</p></main>',
+			wrapperHtml: '<div class="js-bge-content"></div>',
+			contentClass: 'js-bge-content',
+		});
+
+		expect(result).toBe('<main class="js-bge-content"></main>');
+	});
+
+	test('main要素自身のタグ名・属性以外の属性（idなど）は保持される', () => {
+		const result = mergeMainContent({
+			mainHtml: '<main id="content" class="l-main"><p>old</p></main>',
+			wrapperHtml: '<div class="wrap"><p>new</p></div>',
+			contentClass: 'js-bge-content',
+		});
+
+		expect(result).toBe(
+			'<main id="content" class="l-main js-bge-content"><p>new</p></main>',
+		);
+	});
+
+	test('mainHtmlが単一要素にパースできない場合は例外を投げる', () => {
+		expect(() =>
+			mergeMainContent({
+				mainHtml: 'not an element',
+				wrapperHtml: '<div class="wrap"></div>',
+				contentClass: 'wrap',
+			}),
+		).toThrow(/mainHtml did not parse/);
+	});
+
+	test('複数ブロックのラッパー中身をすべて移し替える', () => {
+		const result = mergeMainContent({
+			mainHtml: '<main></main>',
+			wrapperHtml: '<div class="wrap"><div>A</div><div>B</div></div>',
+			contentClass: 'wrap',
+		});
+
+		expect(result).toBe('<main class="wrap"><div>A</div><div>B</div></main>');
+	});
+});

--- a/packages/@d-zero/site-migrator/src/html/merge-main-content.ts
+++ b/packages/@d-zero/site-migrator/src/html/merge-main-content.ts
@@ -1,0 +1,88 @@
+import type { DefaultTreeAdapterMap } from 'parse5';
+
+import { parseFragment, serializeOuter } from 'parse5';
+
+type Element = DefaultTreeAdapterMap['element'];
+type Node = DefaultTreeAdapterMap['childNode'];
+
+export interface MergeMainContentOptions {
+	/** `extractMainContent`が返した、マッチした要素の`outerHTML`（単一要素）。 */
+	mainHtml: string;
+	/** `renderBlocks`が返した、`<div class="...">...</div>`形のラッパー要素HTML。 */
+	wrapperHtml: string;
+	/** `main`要素自身の`classList`に追加するクラス名（`--content-class`の値）。 */
+	contentClass: string;
+}
+
+/**
+ * `renderBlocks`が生成したラッパー`<div>`の中身だけを取り出し、既存`main`要素（実際には
+ * `extractMainContent`が判定したいずれかの要素）の子要素をそれで置き換え、`contentClass`を
+ * `main`要素自身の`classList`に追加する。ラッパー`<div>`自体は使い捨てる — 新規ラッパー要素を
+ * 追加で挟まず、BurgerEditorの`editableArea`セレクタが既存の`main`要素自身に一致する設計。
+ * @param options
+ * @example
+ * ```ts
+ * mergeMainContent({
+ *   mainHtml: '<main class="l-main"><p>old</p></main>',
+ *   wrapperHtml: '<div class="js-bge-content"><div data-bge-name="a">new</div></div>',
+ *   contentClass: 'js-bge-content',
+ * });
+ * // => '<main class="l-main js-bge-content"><div data-bge-name="a">new</div></main>'
+ * ```
+ */
+export function mergeMainContent(options: MergeMainContentOptions): string {
+	const { mainHtml, wrapperHtml, contentClass } = options;
+
+	const mainElement = parseSingleElement(mainHtml, 'mainHtml');
+	const wrapperElement = parseSingleElement(wrapperHtml, 'wrapperHtml');
+
+	// Replace by assigning a fresh copy of the array, not by detaching nodes
+	// one at a time in a for-of over a live array — `childNodes` mutates on
+	// every detach, which silently skips every other element mid-iteration.
+	mainElement.childNodes = [...wrapperElement.childNodes];
+	for (const child of mainElement.childNodes) {
+		child.parentNode = mainElement;
+	}
+
+	addClassToken(mainElement, contentClass);
+
+	return serializeOuter(mainElement);
+}
+
+/**
+ * @param html
+ * @param label
+ */
+function parseSingleElement(html: string, label: string): Element {
+	const fragment = parseFragment(html);
+	const element = fragment.childNodes.find((node): node is Element => isElement(node));
+	if (!element) {
+		throw new Error(`${label} did not parse to a single element: ${html}`);
+	}
+	return element;
+}
+
+/**
+ * @param node
+ */
+function isElement(node: Node): node is Element {
+	return 'tagName' in node && Array.isArray((node as Element).attrs);
+}
+
+/**
+ * `class`属性に`token`をトークンとして追加する（既に含まれていれば何もしない）。属性自体が
+ * 無ければ新規に追加する。
+ * @param element
+ * @param token
+ */
+function addClassToken(element: Element, token: string): void {
+	const classAttr = element.attrs.find((attribute) => attribute.name === 'class');
+	if (!classAttr) {
+		element.attrs.push({ name: 'class', value: token });
+		return;
+	}
+	const tokens = classAttr.value.split(/\s+/u).filter((value) => value.length > 0);
+	if (!tokens.includes(token)) {
+		classAttr.value = [...tokens, token].join(' ');
+	}
+}

--- a/packages/@d-zero/site-migrator/src/migrate.spec.ts
+++ b/packages/@d-zero/site-migrator/src/migrate.spec.ts
@@ -1,3 +1,5 @@
+import type { LayoutBlock } from '@d-zero/anatomist/types';
+
 import { mkdtemp, readFile, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
@@ -27,6 +29,9 @@ vi.mock('./page-extractor/rewrite-page-refs.js', async (importOriginal) => {
 		rewritePageRefs: vi.fn(actual.rewritePageRefs),
 	};
 });
+vi.mock('./page-extractor/resolve-page-layout.js', () => ({
+	resolvePageLayouts: vi.fn(),
+}));
 
 const { openArchive } = await import('./archive/open-archive.js');
 const { listInternalResources } = await import('./archive/list-internal-resources.js');
@@ -34,6 +39,7 @@ const { listInternalPages } = await import('./archive/list-internal-pages.js');
 const { getPageHtml } = await import('./archive/get-page-html.js');
 const { getFrontmatter } = await import('./archive/get-frontmatter.js');
 const { rewritePageRefs } = await import('./page-extractor/rewrite-page-refs.js');
+const { resolvePageLayouts } = await import('./page-extractor/resolve-page-layout.js');
 const { migrate } = await import('./migrate.js');
 
 const openArchiveMock = vi.mocked(openArchive);
@@ -42,6 +48,61 @@ const listInternalPagesMock = vi.mocked(listInternalPages);
 const getPageHtmlMock = vi.mocked(getPageHtml);
 const getFrontmatterMock = vi.mocked(getFrontmatter);
 const rewritePageRefsMock = vi.mocked(rewritePageRefs);
+const resolvePageLayoutsMock = vi.mocked(resolvePageLayouts);
+
+const CONTENT_CLASS = 'js-bge-content';
+
+/**
+ * @param overrides
+ */
+function sampleLeafBlock(overrides: Partial<LayoutBlock> = {}): LayoutBlock {
+	return {
+		layoutType: 'leaf',
+		tagName: 'DIV',
+		id: null,
+		classList: [],
+		boundingBox: { x: 0, y: 0, width: 0, height: 0 },
+		innerHTML: '',
+		confidence: 0,
+		signals: {},
+		children: [],
+		...overrides,
+	};
+}
+
+/**
+ * `resolvePageLayouts`のモックを、渡された全URLについて「main一致・単一wysiwygブロックへの
+ * 変換に成功する」決定的な結果を返すよう設定する（`extract-pages.spec.ts`と同じ方針）。
+ * @param innerHTMLByUrl 単一文字列なら全URL共通、`Record`ならURLごとの`innerHTML`（未指定は空）。
+ */
+function mockConvertedLayout(innerHTMLByUrl: Record<string, string> | string = ''): void {
+	resolvePageLayoutsMock.mockImplementation((options) => {
+		for (const item of options.items) {
+			const innerHTML =
+				typeof innerHTMLByUrl === 'string'
+					? innerHTMLByUrl
+					: (innerHTMLByUrl[item.url] ?? '');
+			options.onResult?.({
+				url: item.url,
+				outcome: 'resolved-live',
+				results: [
+					{
+						url: item.url,
+						viewport: { name: 'pc', width: 1280 },
+						mainSelector: 'main',
+						root: {
+							...sampleLeafBlock(),
+							layoutType: 'vertical-stack',
+							confidence: 1,
+							children: [sampleLeafBlock({ innerHTML })],
+						},
+					},
+				],
+			});
+		}
+		return Promise.resolve();
+	});
+}
 
 const closeMock = vi.fn(() => Promise.resolve());
 
@@ -81,6 +142,12 @@ describe('migrate', () => {
 			'./page-extractor/rewrite-page-refs.js',
 		);
 		rewritePageRefsMock.mockImplementation(real.rewritePageRefs);
+		resolvePageLayoutsMock.mockReset();
+		// Default: layout resolution + block conversion succeeds for every
+		// matched page, producing one empty wysiwyg block. Most tests here are
+		// about the resource/page pipeline orchestration, not about block
+		// conversion itself (that's `extract-pages.spec.ts`'s concern).
+		mockConvertedLayout();
 		closeMock.mockClear();
 
 		openArchiveMock.mockResolvedValue({
@@ -117,6 +184,7 @@ describe('migrate', () => {
 		const report = await migrate({
 			archivePath: '/tmp/fake.nitpicker',
 			outputDir,
+			contentClass: CONTENT_CLASS,
 		});
 
 		expect(report).toEqual({
@@ -130,8 +198,83 @@ describe('migrate', () => {
 			pagesFailed: 0,
 			pagesRewriteFailed: 0,
 			pagesMetaFailed: 0,
+			pagesBlockConverted: 1,
+			pagesBlockPartial: 0,
+			pagesBlockConversionFailed: 0,
 		});
 		expect(closeMock).toHaveBeenCalledTimes(1);
+	});
+
+	test('aggregates pagesBlockPartial and pagesBlockConversionFailed from distinct pages', async () => {
+		listInternalResourcesMock.mockReturnValue(iter([]));
+		listInternalPagesMock.mockReturnValue(
+			iter([
+				{ url: 'https://example.com/partial' },
+				{ url: 'https://example.com/fatal' },
+			]),
+		);
+		vi.stubGlobal('fetch', vi.fn());
+		getPageHtmlMock.mockResolvedValueOnce(
+			'<!doctype html><html><head></head><body><main><p>x</p></main></body></html>',
+		);
+		getPageHtmlMock.mockResolvedValueOnce(
+			'<!doctype html><html><head></head><body><main><p>y</p></main></body></html>',
+		);
+		resolvePageLayoutsMock.mockImplementation((options) => {
+			for (const item of options.items) {
+				if (item.url === 'https://example.com/partial') {
+					// simple-grid with malformed rowSizes → the block falls back to
+					// wysiwyg, but the page itself is still `converted`→`partial`.
+					options.onResult?.({
+						url: item.url,
+						outcome: 'resolved-live',
+						results: [
+							{
+								url: item.url,
+								viewport: { name: 'pc', width: 1280 },
+								mainSelector: 'main',
+								root: {
+									...sampleLeafBlock(),
+									layoutType: 'vertical-stack',
+									confidence: 1,
+									children: [
+										{
+											...sampleLeafBlock(),
+											layoutType: 'simple-grid',
+											confidence: 0.9,
+											signals: { rowSizes: [3] },
+											children: [sampleLeafBlock()],
+										},
+									],
+								},
+							},
+						],
+					});
+				} else {
+					// Fatal: resolvePageLayouts failed outright for this page.
+					options.onResult?.({
+						url: item.url,
+						outcome: 'missing',
+						error: new Error('live analysis failed'),
+						kind: 'unknown',
+					});
+				}
+			}
+			return Promise.resolve();
+		});
+
+		const report = await migrate({
+			archivePath: '/tmp/fake.nitpicker',
+			outputDir,
+			contentClass: CONTENT_CLASS,
+		});
+
+		expect(report).toMatchObject({
+			pagesExtracted: 2,
+			pagesBlockConverted: 0,
+			pagesBlockPartial: 1,
+			pagesBlockConversionFailed: 1,
+		});
 	});
 
 	test('forwards onResource and onPage callbacks for every per-item event', async () => {
@@ -152,6 +295,7 @@ describe('migrate', () => {
 		await migrate({
 			archivePath: '/tmp/fake.nitpicker',
 			outputDir,
+			contentClass: CONTENT_CLASS,
 			onResource: (event) => resources.push(event),
 			onPage: (event) => pages.push(event),
 		});
@@ -189,11 +333,18 @@ describe('migrate', () => {
 			);
 		});
 
-		await migrate({ archivePath: '/tmp/fake.nitpicker', outputDir });
+		await migrate({
+			archivePath: '/tmp/fake.nitpicker',
+			outputDir,
+			contentClass: CONTENT_CLASS,
+		});
 
 		expect(callOrder).toEqual(['fetch', 'getPageHtml']);
 		const written = await readFile(path.join(outputDir, 'p1.html'), 'utf8');
-		expect(written).toBe('---\nid: 5\n---\n<main>PAGE</main>');
+		expect(written.startsWith(`---\nid: 5\n---\n<main class="${CONTENT_CLASS}">`)).toBe(
+			true,
+		);
+		expect(written.endsWith('</main>')).toBe(true);
 	});
 
 	test('end-to-end: prepends YAML frontmatter (id + DB meta) to the extracted HTML', async () => {
@@ -208,12 +359,18 @@ describe('migrate', () => {
 			og: { title: 'OG P1' },
 		});
 
-		await migrate({ archivePath: '/tmp/fake.nitpicker', outputDir });
+		await migrate({
+			archivePath: '/tmp/fake.nitpicker',
+			outputDir,
+			contentClass: CONTENT_CLASS,
+		});
 
 		const written = await readFile(path.join(outputDir, 'p1.html'), 'utf8');
-		expect(written).toBe(
-			'---\nid: 5\ntitle: "P1"\nog:\n  title: "OG P1"\n---\n<main><p>body</p></main>',
-		);
+		expect(
+			written.startsWith(
+				`---\nid: 5\ntitle: "P1"\nog:\n  title: "OG P1"\n---\n<main class="${CONTENT_CLASS}">`,
+			),
+		).toBe(true);
 	});
 
 	test('end-to-end: rewrites same-origin <a href> to {{<id>}} and assets to root-relative paths', async () => {
@@ -225,27 +382,31 @@ describe('migrate', () => {
 			]),
 		);
 		vi.stubGlobal('fetch', vi.fn());
+		const indexInnerHtml =
+			'<a href="/about/">about</a>' +
+			'<img src="../img/logo.png">' +
+			'<a href="https://other.example/x">ext</a>';
 		getPageHtmlMock.mockResolvedValueOnce(
-			'<!doctype html><html><head></head><body><main>' +
-				'<a href="/about/">about</a>' +
-				'<img src="../img/logo.png">' +
-				'<a href="https://other.example/x">ext</a>' +
-				'</main></body></html>',
+			`<!doctype html><html><head></head><body><main>${indexInnerHtml}</main></body></html>`,
 		);
 		getPageHtmlMock.mockResolvedValueOnce(
 			'<!doctype html><html><head></head><body><main>body</main></body></html>',
 		);
+		// Route the same markup through the mocked block so the merged body
+		// (what rewritePageRefs actually runs against) contains it.
+		mockConvertedLayout({ 'https://example.com/index.html': indexInnerHtml });
 
-		await migrate({ archivePath: '/tmp/fake.nitpicker', outputDir });
+		await migrate({
+			archivePath: '/tmp/fake.nitpicker',
+			outputDir,
+			contentClass: CONTENT_CLASS,
+		});
 
 		const written = await readFile(path.join(outputDir, 'index.html'), 'utf8');
-		expect(written).toBe(
-			'---\nid: 5\n---\n<main>' +
-				'<a href="{{10000}}">about</a>' +
-				'<img src="/img/logo.png">' +
-				'<a href="https://other.example/x">ext</a>' +
-				'</main>',
-		);
+		expect(written).toContain('{{10000}}');
+		expect(written).toContain('<img src="/img/logo.png">');
+		expect(written).toContain('https://other.example/x');
+		expect(written).not.toContain('href="/about/"');
 	});
 
 	test('counts pages whose rewritePageRefs rejection was surfaced as rewriteError under pagesRewriteFailed', async () => {
@@ -257,7 +418,11 @@ describe('migrate', () => {
 		);
 		rewritePageRefsMock.mockRejectedValueOnce(new Error('rewrite boom'));
 
-		const report = await migrate({ archivePath: '/tmp/fake.nitpicker', outputDir });
+		const report = await migrate({
+			archivePath: '/tmp/fake.nitpicker',
+			outputDir,
+			contentClass: CONTENT_CLASS,
+		});
 
 		expect(report).toMatchObject({
 			pagesExtracted: 1,
@@ -277,7 +442,11 @@ describe('migrate', () => {
 		getFrontmatterMock.mockReset();
 		getFrontmatterMock.mockRejectedValueOnce(new Error('sqlite boom'));
 
-		const report = await migrate({ archivePath: '/tmp/fake.nitpicker', outputDir });
+		const report = await migrate({
+			archivePath: '/tmp/fake.nitpicker',
+			outputDir,
+			contentClass: CONTENT_CLASS,
+		});
 
 		expect(report).toMatchObject({
 			pagesExtracted: 1,
@@ -293,7 +462,11 @@ describe('migrate', () => {
 		listInternalPagesMock.mockReturnValue(iter([]));
 
 		await expect(
-			migrate({ archivePath: '/tmp/fake.nitpicker', outputDir }),
+			migrate({
+				archivePath: '/tmp/fake.nitpicker',
+				outputDir,
+				contentClass: CONTENT_CLASS,
+			}),
 		).rejects.toThrow('listing crashed');
 		expect(closeMock).toHaveBeenCalledTimes(1);
 	});

--- a/packages/@d-zero/site-migrator/src/migrate.ts
+++ b/packages/@d-zero/site-migrator/src/migrate.ts
@@ -13,11 +13,30 @@ import { extractPages } from './page-extractor/extract-pages.js';
 export interface MigrateOptions {
 	archivePath: string;
 	outputDir: string;
+	/**
+	 * BurgerEditorの`editableArea`セレクタに対応させるクラス名。生成したブロック群を
+	 * 埋め込む既存main要素自身の`classList`に追加する。移行先サイトのBurgerEditor設定に
+	 * 依存する値であり、決め打ちのデフォルトを持たせると気づかれないまま不整合な出力を
+	 * 生成しうるため必須（{@link import('./page-extractor/extract-pages.js').ExtractPagesOptions.contentClass}参照）。
+	 */
+	contentClass: string;
+	/**
+	 * 事前生成済みのanatomistレイアウト解析JSONL（1ファイルで全URL分）。
+	 * {@link import('./page-extractor/extract-pages.js').extractPages}にそのまま転送される。
+	 * 省略時は全ページをライブ解析する。
+	 */
+	layoutJsonPath?: string;
 	/** Maximum concurrent downloads. Defaults to 10. */
 	downloadLimit?: number;
 	/** Maximum concurrent page extractions. Defaults to 10. */
 	extractLimit?: number;
-	/** Forwarded to {@link downloadResources}; useful for CLI progress logging. */
+	/**
+	 * Forwarded to both {@link downloadResources}（通常のリソースDL）と`extractPages`の
+	 * block内`download-file`アイテムの追加DL。後者は`MigrateReport`の`totalResources`/
+	 * `resourcesSaved`/`resourcesFailed`には含まれない（`totalResources`は中断時の
+	 * skip検出に使う既知の総数であり、実行中に動的発見される追加DL分を混ぜると
+	 * その計算が壊れるため）。ログ等での可視化のみこのコールバックで行う。
+	 */
 	onResource?: (event: DownloadResult) => void;
 	/** Per-page extraction progress callback. */
 	onPage?: (event: ExtractPageResult) => void;
@@ -46,6 +65,18 @@ export interface MigrateReport {
 	 * reason as `pagesRewriteFailed`.
 	 */
 	pagesMetaFailed: number;
+	/** Subset of `pagesExtracted` whose ブロック変換が全ブロック成功した（`blockConversion: 'converted'`）。 */
+	pagesBlockConverted: number;
+	/**
+	 * Subset of `pagesExtracted` whose 一部ブロックのみ低信頼度でwysiwygフォールバックされたが
+	 * 致命的ではなかった（`blockConversion: 'partial'`）。
+	 */
+	pagesBlockPartial: number;
+	/**
+	 * Subset of `pagesExtracted` whose 致命的エラーによりページ全体がプレーンHTML
+	 * （`data-bge-*`マーカー無し）で出力された（`blockConversion: 'fallback'`）。
+	 */
+	pagesBlockConversionFailed: number;
 }
 
 /**
@@ -65,6 +96,8 @@ export async function migrate(options: MigrateOptions): Promise<MigrateReport> {
 	const {
 		archivePath,
 		outputDir,
+		contentClass,
+		layoutJsonPath,
 		downloadLimit,
 		extractLimit,
 		onResource,
@@ -84,8 +117,19 @@ export async function migrate(options: MigrateOptions): Promise<MigrateReport> {
 			pageItems.push({ url: page.url });
 		}
 
+		// `totalResources`/`resourcesSaved`/`resourcesFailed` cover only this
+		// upfront, fully-enumerated pass — `resourcesSkipped` in the CLI is
+		// derived as `totalResources - (resourcesSaved + resourcesFailed)`, so
+		// `totalResources` must stay the fixed, known-upfront count for that
+		// arithmetic to mean anything (e.g. after a SIGINT abort). The block
+		// conversion pipeline's own `download-file` dedupe pass (see below)
+		// discovers extra URLs *during* page extraction — those still reach
+		// the caller's `onResource` for visibility, but are intentionally left
+		// out of these three counters rather than corrupting the skip count.
+		const totalResources = resourceItems.length;
 		let resourcesSaved = 0;
 		let resourcesFailed = 0;
+
 		await downloadResources({
 			items: resourceItems,
 			outputDir,
@@ -105,22 +149,44 @@ export async function migrate(options: MigrateOptions): Promise<MigrateReport> {
 		// (rare — typically a stand-alone `.html` referenced as a sub-resource),
 		// the layout-stripped page output is the canonical version and should
 		// win over the raw network body.
+		const knownResourceUrls = new Set(resourceItems.map((item) => item.url));
 		let pagesExtracted = 0;
 		let pagesFallback = 0;
 		let pagesMissing = 0;
 		let pagesFailed = 0;
 		let pagesRewriteFailed = 0;
 		let pagesMetaFailed = 0;
+		let pagesBlockConverted = 0;
+		let pagesBlockPartial = 0;
+		let pagesBlockConversionFailed = 0;
 		await extractPages({
 			session,
 			items: pageItems,
 			outputDir,
+			contentClass,
+			layoutJsonPath,
+			knownResourceUrls,
 			limit: extractLimit,
 			signal,
+			onResource,
 			onResult: (event) => {
 				switch (event.outcome) {
 					case 'extracted': {
 						pagesExtracted += 1;
+						switch (event.blockConversion) {
+							case 'converted': {
+								pagesBlockConverted += 1;
+								break;
+							}
+							case 'partial': {
+								pagesBlockPartial += 1;
+								break;
+							}
+							case 'fallback': {
+								pagesBlockConversionFailed += 1;
+								break;
+							}
+						}
 						break;
 					}
 					case 'fallback': {
@@ -153,7 +219,7 @@ export async function migrate(options: MigrateOptions): Promise<MigrateReport> {
 		});
 
 		return {
-			totalResources: resourceItems.length,
+			totalResources,
 			resourcesSaved,
 			resourcesFailed,
 			totalPages: pageItems.length,
@@ -163,6 +229,9 @@ export async function migrate(options: MigrateOptions): Promise<MigrateReport> {
 			pagesFailed,
 			pagesRewriteFailed,
 			pagesMetaFailed,
+			pagesBlockConverted,
+			pagesBlockPartial,
+			pagesBlockConversionFailed,
 		};
 	} finally {
 		await session.close();

--- a/packages/@d-zero/site-migrator/src/page-extractor/check-main-consistency.spec.ts
+++ b/packages/@d-zero/site-migrator/src/page-extractor/check-main-consistency.spec.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from 'vitest';
+
+import { isMainConsistent } from './check-main-consistency.js';
+
+const docWith = (body: string) =>
+	`<!doctype html><html><head><title>t</title></head><body>${body}</body></html>`;
+
+describe('isMainConsistent', () => {
+	test('mainSelectorがnullの場合は無条件に不整合とみなす', () => {
+		const html = docWith('<main><p>x</p></main>');
+		expect(isMainConsistent(html, '<main><p>x</p></main>', null)).toBe(false);
+	});
+
+	test('mainSelectorが指す要素のouterHTMLがextractMainContentのマッチと一致すれば整合', () => {
+		const html = docWith('<main class="l-main"><p>x</p></main>');
+		expect(isMainConsistent(html, '<main class="l-main"><p>x</p></main>', 'main')).toBe(
+			true,
+		);
+	});
+
+	test('mainSelectorが別の要素を指している場合は不整合', () => {
+		const html = docWith('<main><p>x</p></main><section><p>y</p></section>');
+		expect(isMainConsistent(html, '<main><p>x</p></main>', 'section')).toBe(false);
+	});
+
+	test('mainSelectorにマッチする要素が存在しない場合は不整合', () => {
+		const html = docWith('<main><p>x</p></main>');
+		expect(isMainConsistent(html, '<main><p>x</p></main>', '.does-not-exist')).toBe(
+			false,
+		);
+	});
+
+	test('mainSelectorが不正なセレクタで例外を投げる場合も不整合として扱う', () => {
+		const html = docWith('<main><p>x</p></main>');
+		expect(isMainConsistent(html, '<main><p>x</p></main>', ':::invalid:::')).toBe(false);
+	});
+});

--- a/packages/@d-zero/site-migrator/src/page-extractor/check-main-consistency.ts
+++ b/packages/@d-zero/site-migrator/src/page-extractor/check-main-consistency.ts
@@ -1,0 +1,41 @@
+import { JSDOM } from 'jsdom';
+
+/**
+ * anatomistの`mainSelector`（構造判定の主ビューポートのもの）と`extractMainContent`が
+ * マッチした要素を比較し、両者が同一要素を指しているかを判定する、ページ単位の致命的
+ * フォールバック判定に使う簡易版の整合性チェック。#978「anatomistとextractMainContentの
+ * main要素検出結果を整合させる」が担う厳密な整合化の完全な実装ではない。
+ *
+ * `mainSelector`が`null`の場合（anatomistがmain候補を検出できなかった）は、この関数の
+ * 呼び出し元が`extracted`（`extractMainContent`はマッチ済み）の場合にのみ呼ぶ前提のため、
+ * 無条件に不整合とみなす。セレクタが不正でDOM側の`querySelector`が例外を投げた場合や、
+ * セレクタにマッチする要素が無かった場合も同様に不整合として扱う（安全側）。
+ *
+ * 一致判定は`outerHTML`の完全一致で行う。DOM構造として同一要素であっても属性順序や
+ * 空白の正規化差でずれる可能性があるが、`extractMainContent`（parse5）と本関数のjsdom
+ * パースは同じ`originalHtml`文字列を独立にパースするため、同一要素であれば通常
+ * `outerHTML`も一致する。誤検出（実際は同一要素なのに不一致と判定）が起きても、
+ * 呼び出し側は安全側（致命的フォールバックへの倒し込み）に働くだけなので許容する。
+ * @param originalHtml ページの元の完全なHTMLドキュメント。
+ * @param matchedMainHtml `extractMainContent`がマッチしたと判定した要素の`outerHTML`。
+ * @param mainSelector anatomistの`LayoutAnalysisResult.mainSelector`（主ビューポート分）。
+ */
+export function isMainConsistent(
+	originalHtml: string,
+	matchedMainHtml: string,
+	mainSelector: string | null,
+): boolean {
+	if (mainSelector === null) {
+		return false;
+	}
+
+	let anatomistElement: Element | null;
+	try {
+		const dom = new JSDOM(originalHtml);
+		anatomistElement = dom.window.document.querySelector(mainSelector);
+	} catch {
+		return false;
+	}
+
+	return anatomistElement !== null && anatomistElement.outerHTML === matchedMainHtml;
+}

--- a/packages/@d-zero/site-migrator/src/page-extractor/download-block-files.spec.ts
+++ b/packages/@d-zero/site-migrator/src/page-extractor/download-block-files.spec.ts
@@ -1,0 +1,193 @@
+import type { BlockData } from '@burger-editor/core';
+
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { downloadBlockFiles } from './download-block-files.js';
+
+/**
+ * @param path_
+ */
+function downloadFileBlock(path_: string): BlockData {
+	return {
+		name: 'migrated',
+		containerProps: { type: 'grid', columns: 1 },
+		items: [
+			[
+				{
+					name: 'download-file',
+					data: {
+						path: path_,
+						download: '',
+						name: '',
+						formatedSize: '',
+						size: '',
+						downloadCheck: false,
+					},
+				},
+			],
+		],
+	};
+}
+
+describe('downloadBlockFiles', () => {
+	let outputDir = '';
+
+	beforeEach(async () => {
+		outputDir = await mkdtemp(path.join(tmpdir(), 'site-migrator-download-block-'));
+	});
+
+	afterEach(async () => {
+		await rm(outputDir, { recursive: true, force: true });
+		vi.unstubAllGlobals();
+	});
+
+	test('未知のdownload-file候補を実DLし、size/formatedSizeを実測値で書き戻す', async () => {
+		vi.stubGlobal(
+			'fetch',
+			vi.fn(() =>
+				Promise.resolve(
+					new Response(new Uint8Array(2048), {
+						status: 200,
+						headers: { 'content-type': 'application/pdf' },
+					}),
+				),
+			),
+		);
+
+		const block = downloadFileBlock('/files/a.pdf');
+		await downloadBlockFiles({
+			blocksByUrl: new Map([['https://example.com/p', [block]]]),
+			outputDir,
+			knownResourceUrls: new Set(),
+		});
+
+		const item = block.items[0]![0] as { data: { size: string; formatedSize: string } };
+		expect(item.data.size).toBe('2048');
+		expect(item.data.formatedSize).toBe('2.0KB');
+		const written = await readFile(path.join(outputDir, 'files', 'a.pdf'));
+		expect(written).toHaveLength(2048);
+	});
+
+	test('knownResourceUrlsに含まれるURLは再ダウンロードしない', async () => {
+		const fetchMock = vi.fn();
+		vi.stubGlobal('fetch', fetchMock);
+		// Pre-populate the file as if the main resource-download pass already saved it.
+		const outputPath = path.join(outputDir, 'files', 'a.pdf');
+		await import('node:fs/promises').then(({ mkdir, writeFile }) =>
+			mkdir(path.dirname(outputPath), { recursive: true }).then(() =>
+				writeFile(outputPath, new Uint8Array(10)),
+			),
+		);
+
+		const block = downloadFileBlock('/files/a.pdf');
+		await downloadBlockFiles({
+			blocksByUrl: new Map([['https://example.com/p', [block]]]),
+			outputDir,
+			knownResourceUrls: new Set(['https://example.com/files/a.pdf']),
+		});
+
+		expect(fetchMock).not.toHaveBeenCalled();
+		const item = block.items[0]![0] as { data: { size: string; formatedSize: string } };
+		// Still reflects the real size on disk, even though no new download ran.
+		expect(item.data.size).toBe('10');
+	});
+
+	test('同一URLを参照する複数ブロックのアイテム全てにsizeを反映する', async () => {
+		vi.stubGlobal(
+			'fetch',
+			vi.fn(() => Promise.resolve(new Response(new Uint8Array(5), { status: 200 }))),
+		);
+
+		const blockA = downloadFileBlock('/files/shared.pdf');
+		const blockB = downloadFileBlock('https://example.com/files/shared.pdf');
+		await downloadBlockFiles({
+			blocksByUrl: new Map([
+				['https://example.com/pageA', [blockA]],
+				['https://example.com/pageB', [blockB]],
+			]),
+			outputDir,
+			knownResourceUrls: new Set(),
+		});
+
+		expect((blockA.items[0]![0] as { data: { size: string } }).data.size).toBe('5');
+		expect((blockB.items[0]![0] as { data: { size: string } }).data.size).toBe('5');
+	});
+
+	test('ダウンロードが失敗した場合はsize/formatedSizeがプレースホルダーのまま残る', async () => {
+		vi.stubGlobal(
+			'fetch',
+			vi.fn(() => Promise.resolve(new Response('not found', { status: 404 }))),
+		);
+
+		const block = downloadFileBlock('/files/missing.pdf');
+		await downloadBlockFiles({
+			blocksByUrl: new Map([['https://example.com/p', [block]]]),
+			outputDir,
+			knownResourceUrls: new Set(),
+		});
+
+		const item = block.items[0]![0] as { data: { size: string; formatedSize: string } };
+		expect(item.data.size).toBe('');
+		expect(item.data.formatedSize).toBe('');
+	});
+
+	test('1024バイト未満のファイルはB単位（小数無し）でformatedSizeを表す', async () => {
+		vi.stubGlobal(
+			'fetch',
+			vi.fn(() => Promise.resolve(new Response(new Uint8Array(500), { status: 200 }))),
+		);
+
+		const block = downloadFileBlock('/files/small.pdf');
+		await downloadBlockFiles({
+			blocksByUrl: new Map([['https://example.com/p', [block]]]),
+			outputDir,
+			knownResourceUrls: new Set(),
+		});
+
+		const item = block.items[0]![0] as { data: { size: string; formatedSize: string } };
+		expect(item.data.size).toBe('500');
+		expect(item.data.formatedSize).toBe('500B');
+	});
+
+	test('パースできないpath（URLとして不正）を持つアイテムは例外を投げずスキップする', async () => {
+		const fetchMock = vi.fn();
+		vi.stubGlobal('fetch', fetchMock);
+
+		// A raw space in the host makes `new URL(...)` throw regardless of base,
+		// since the value carries its own (invalid) scheme.
+		const block = downloadFileBlock('https://ex ample.invalid/a.pdf');
+		await expect(
+			downloadBlockFiles({
+				blocksByUrl: new Map([['https://example.com/p', [block]]]),
+				outputDir,
+				knownResourceUrls: new Set(),
+			}),
+		).resolves.toBeUndefined();
+
+		expect(fetchMock).not.toHaveBeenCalled();
+		const item = block.items[0]![0] as { data: { size: string; formatedSize: string } };
+		expect(item.data.size).toBe('');
+	});
+
+	test('download-fileアイテムが無ければ何もしない（downloadResourcesを呼ばない）', async () => {
+		const fetchMock = vi.fn();
+		vi.stubGlobal('fetch', fetchMock);
+
+		const block: BlockData = {
+			name: 'migrated',
+			containerProps: { type: 'grid', columns: 1 },
+			items: [[{ name: 'wysiwyg', data: { wysiwyg: '<p>x</p>' } }]],
+		};
+		await downloadBlockFiles({
+			blocksByUrl: new Map([['https://example.com/p', [block]]]),
+			outputDir,
+			knownResourceUrls: new Set(),
+		});
+
+		expect(fetchMock).not.toHaveBeenCalled();
+	});
+});

--- a/packages/@d-zero/site-migrator/src/page-extractor/download-block-files.ts
+++ b/packages/@d-zero/site-migrator/src/page-extractor/download-block-files.ts
@@ -1,0 +1,140 @@
+import type { DownloadFileItemData } from './classify-block-item.js';
+import type { BlockData } from '@burger-editor/core';
+
+import { stat } from 'node:fs/promises';
+
+import {
+	downloadResources,
+	type DownloadResult,
+} from '../downloader/download-resources.js';
+import { urlToOutputPath } from '../downloader/url-to-output-path.js';
+
+export interface DownloadBlockFilesOptions {
+	/**
+	 * ページURL → そのページの`BlockData`配列。`download-file`アイテムの`data`は
+	 * この関数が直接書き換える（`size`/`formatedSize`を実測値で上書きする）。
+	 */
+	blocksByUrl: ReadonlyMap<string, readonly BlockData[]>;
+	outputDir: string;
+	/** 通常のリソースDL（`listInternalResources`由来）で既にカバー済みの絶対URL集合。二重DL回避用。 */
+	knownResourceUrls: ReadonlySet<string>;
+	/** `downloadResources`へ転送する並列数。 */
+	limit?: number;
+	onResult?: (event: DownloadResult) => void;
+	signal?: AbortSignal;
+}
+
+/**
+ * 各ページの`BlockData`木を走査して`download-file`アイテムの`path`（href、相対の場合あり）を
+ * 集め、ページURLを基準に絶対URLへ解決したうえで`knownResourceUrls`（通常のリソースDLで
+ * 既にカバーされるURL集合）と重複しないものだけを`downloadResources`へ追加投入する
+ * （fetch処理そのものは再実装せず`downloadResources`に一本化する）。
+ *
+ * ダウンロード後（または既に`knownResourceUrls`でカバー済みでダウンロードをスキップした場合も
+ * 含めて）、出力パスの実ファイルサイズを`stat`で読み、該当する全アイテムの`size`/
+ * `formatedSize`を書き戻す。同一ファイルが複数ページ・複数アイテムから参照されていても
+ * ダウンロードは1回で済ませ、全参照箇所に反映する。
+ *
+ * ダウンロードが行われなかった、または失敗した場合は`size`/`formatedSize`を
+ * プレースホルダー（空文字列）のまま残す fail-soft 方針（`classifyBlockItem`が生成した時点の
+ * 初期値のまま）。
+ *
+ * 実データでは`classifyBlockItem`がhref/src等の属性欠如によりほぼ常に`wysiwyg`へフォールバック
+ * するため（`classify-block-item.ts`のJSDoc参照）、`download-file`アイテムが実際に生成される
+ * ケース自体が稀である。それでも型上ありうる経路として実装している。
+ * @param options
+ */
+export async function downloadBlockFiles(
+	options: DownloadBlockFilesOptions,
+): Promise<void> {
+	const { blocksByUrl, outputDir, knownResourceUrls, limit, onResult, signal } = options;
+
+	const targets = new Map<string, DownloadFileItemData[]>();
+	for (const [pageUrl, blocks] of blocksByUrl) {
+		for (const item of iterateDownloadFileItems(blocks)) {
+			let absoluteUrl: string;
+			try {
+				absoluteUrl = new URL(item.path, pageUrl).href;
+			} catch {
+				continue;
+			}
+			const bucket = targets.get(absoluteUrl);
+			if (bucket) {
+				bucket.push(item);
+			} else {
+				targets.set(absoluteUrl, [item]);
+			}
+		}
+	}
+	if (targets.size === 0) {
+		return;
+	}
+
+	const toDownload = [...targets.keys()].filter((url) => !knownResourceUrls.has(url));
+	if (toDownload.length > 0) {
+		await downloadResources({
+			items: toDownload.map((url) => ({ url })),
+			outputDir,
+			limit,
+			signal,
+			onResult,
+		});
+	}
+
+	await Promise.all(
+		[...targets.entries()].map(async ([url, items]) => {
+			let outputPath: string;
+			try {
+				outputPath = urlToOutputPath(url, outputDir);
+			} catch {
+				return;
+			}
+			try {
+				const info = await stat(outputPath);
+				const formatted = formatBytes(info.size);
+				for (const item of items) {
+					item.size = String(info.size);
+					item.formatedSize = formatted;
+				}
+			} catch {
+				/* ダウンロードされなかった（失敗・スキップ）場合はプレースホルダーのまま。 */
+			}
+		}),
+	);
+}
+
+const UNITS = ['B', 'KB', 'MB', 'GB'] as const;
+
+/**
+ * @param bytes
+ */
+function formatBytes(bytes: number): string {
+	if (bytes < 1024) {
+		return `${bytes}B`;
+	}
+	let value = bytes;
+	let unitIndex = 0;
+	while (value >= 1024 && unitIndex < UNITS.length - 1) {
+		value /= 1024;
+		unitIndex += 1;
+	}
+	return `${value.toFixed(1)}${UNITS[unitIndex]}`;
+}
+
+/**
+ * @param blocks
+ * @yields 各`download-file`アイテムの`data`（`BlockData`木を文書順で走査）。
+ */
+function* iterateDownloadFileItems(
+	blocks: readonly BlockData[],
+): Generator<DownloadFileItemData> {
+	for (const block of blocks) {
+		for (const row of block.items) {
+			for (const item of row) {
+				if (typeof item !== 'string' && item.name === 'download-file' && item.data) {
+					yield item.data as DownloadFileItemData;
+				}
+			}
+		}
+	}
+}

--- a/packages/@d-zero/site-migrator/src/page-extractor/extract-pages.spec.ts
+++ b/packages/@d-zero/site-migrator/src/page-extractor/extract-pages.spec.ts
@@ -1,4 +1,5 @@
 import type { ArchiveSession } from '../types.js';
+import type { LayoutBlock } from '@d-zero/anatomist/types';
 
 import { mkdtemp, readFile, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
@@ -9,6 +10,7 @@ import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import { extractPages, type ExtractPageResult } from './extract-pages.js';
 
 type RewritePageRefsModule = typeof import('./rewrite-page-refs.js');
+type RenderBlocksModule = typeof import('./render-blocks.js');
 
 vi.mock('../archive/get-page-html.js', () => ({
 	getPageHtml: vi.fn(),
@@ -23,13 +25,27 @@ vi.mock('./rewrite-page-refs.js', async (importOriginal) => {
 		rewritePageRefs: vi.fn(actual.rewritePageRefs),
 	};
 });
+vi.mock('./resolve-page-layout.js', () => ({
+	resolvePageLayouts: vi.fn(),
+}));
+vi.mock('./render-blocks.js', async (importOriginal) => {
+	const actual = await importOriginal<RenderBlocksModule>();
+	return {
+		...actual,
+		renderBlocks: vi.fn(actual.renderBlocks),
+	};
+});
 
 const { getPageHtml } = await import('../archive/get-page-html.js');
 const { getFrontmatter } = await import('../archive/get-frontmatter.js');
 const { rewritePageRefs } = await import('./rewrite-page-refs.js');
+const { resolvePageLayouts } = await import('./resolve-page-layout.js');
+const { renderBlocks } = await import('./render-blocks.js');
 const getPageHtmlMock = vi.mocked(getPageHtml);
 const getFrontmatterMock = vi.mocked(getFrontmatter);
 const rewritePageRefsMock = vi.mocked(rewritePageRefs);
+const resolvePageLayoutsMock = vi.mocked(resolvePageLayouts);
+const renderBlocksMock = vi.mocked(renderBlocks);
 
 const FAKE_SESSION = {
 	archiveId: 'test',
@@ -39,8 +55,78 @@ const FAKE_SESSION = {
 	},
 } satisfies ArchiveSession;
 
+const CONTENT_CLASS = 'js-bge-content';
+
 const docWith = (body: string) =>
 	`<!doctype html><html><head><title>t</title></head><body>${body}</body></html>`;
+
+/**
+ * @param overrides
+ */
+function sampleLeafBlock(overrides: Partial<LayoutBlock> = {}): LayoutBlock {
+	return {
+		layoutType: 'leaf',
+		tagName: 'DIV',
+		id: null,
+		classList: [],
+		boundingBox: { x: 0, y: 0, width: 0, height: 0 },
+		innerHTML: '',
+		confidence: 0,
+		signals: {},
+		children: [],
+		...overrides,
+	};
+}
+
+/**
+ * `resolvePageLayouts`のモックを、渡された全URLについて「main一致・単一wysiwygブロックへの
+ * 変換に成功する」決定的な結果を返すよう設定する。`mainSelector: 'main'`で、テストフィクスチャの
+ * `<main>...</main>`（`extractMainContent`がタグでマッチする唯一の要素）と一致させる。
+ * @param childInnerHTML 生成される単一wysiwygブロックの`innerHTML`（既定は空）。
+ */
+function mockConvertedLayout(childInnerHTML = ''): void {
+	resolvePageLayoutsMock.mockImplementation((options) => {
+		for (const item of options.items) {
+			options.onResult?.({
+				url: item.url,
+				outcome: 'resolved-live',
+				results: [
+					{
+						url: item.url,
+						viewport: { name: 'pc', width: 1280 },
+						mainSelector: 'main',
+						root: {
+							...sampleLeafBlock(),
+							layoutType: 'vertical-stack',
+							confidence: 1,
+							children: [sampleLeafBlock({ innerHTML: childInnerHTML })],
+						},
+					},
+				],
+			});
+		}
+		return Promise.resolve();
+	});
+}
+
+/**
+ * `resolvePageLayouts`が全URLについて致命的に失敗した（`missing`）ことにするモック。
+ * ページ単位の致命的フォールバック（`blockConversion: 'fallback'`）を発火させるために使う。
+ * @param message
+ */
+function mockMissingLayout(message = 'live analysis failed'): void {
+	resolvePageLayoutsMock.mockImplementation((options) => {
+		for (const item of options.items) {
+			options.onResult?.({
+				url: item.url,
+				outcome: 'missing',
+				error: new Error(message),
+				kind: 'unknown',
+			});
+		}
+		return Promise.resolve();
+	});
+}
 
 describe('extractPages', () => {
 	let outputDir = '';
@@ -49,12 +135,23 @@ describe('extractPages', () => {
 		outputDir = await mkdtemp(path.join(tmpdir(), 'site-migrator-pages-'));
 		getPageHtmlMock.mockReset();
 		getFrontmatterMock.mockReset();
+		resolvePageLayoutsMock.mockReset();
 		// Default: no DB row → only the id is emitted in frontmatter.
 		getFrontmatterMock.mockResolvedValue(null);
-		// Default: delegate to the real rewriter so other tests exercise it.
-		// Override per-test to force a rewrite failure.
-		const real = await vi.importActual<RewritePageRefsModule>('./rewrite-page-refs.js');
-		rewritePageRefsMock.mockImplementation(real.rewritePageRefs);
+		// Default: delegate to the real rewriter/renderer so other tests
+		// exercise the real implementation. Override per-test to force a
+		// failure.
+		const realRewrite = await vi.importActual<RewritePageRefsModule>(
+			'./rewrite-page-refs.js',
+		);
+		rewritePageRefsMock.mockImplementation(realRewrite.rewritePageRefs);
+		const realRender = await vi.importActual<RenderBlocksModule>('./render-blocks.js');
+		renderBlocksMock.mockImplementation(realRender.renderBlocks);
+		// Default: layout resolution + block conversion succeeds for every
+		// matched page, producing one empty wysiwyg block. Most tests here are
+		// about extraction / frontmatter / rewrite behaviour, not about block
+		// conversion itself (that's covered by the dedicated tests below).
+		mockConvertedLayout();
 	});
 
 	afterEach(async () => {
@@ -71,21 +168,32 @@ describe('extractPages', () => {
 			session: FAKE_SESSION,
 			items: [{ url: 'https://example.com/about/' }],
 			outputDir,
+			contentClass: CONTENT_CLASS,
 			limit: 1,
 			onResult: (event) => results.push(event),
 		});
 
-		expect(results).toEqual([
+		expect(results).toMatchObject([
 			{
 				url: 'https://example.com/about/',
 				outcome: 'extracted',
 				outputPath: path.join(outputDir, 'about', 'index.html'),
 				matchedBy: 'tag:main',
+				blockConversion: 'converted',
 			},
 		]);
 		const written = await readFile(path.join(outputDir, 'about', 'index.html'), 'utf8');
 		// `/about/` is the only page in its subdirectory section → id 10000.
-		expect(written).toBe('---\nid: 10000\n---\n<main><p>hello</p></main>');
+		// The original `<p>hello</p>` is replaced by the rendered block group;
+		// exact BurgerEditor markup is `render-blocks.spec.ts`'s concern, so we
+		// only assert the frontmatter, the main-element merge, and that a
+		// block was actually rendered into it.
+		expect(
+			written.startsWith(`---\nid: 10000\n---\n<main class="${CONTENT_CLASS}">`),
+		).toBe(true);
+		expect(written.endsWith('</main>')).toBe(true);
+		expect(written).toContain('data-bge-name="migrated"');
+		expect(written).not.toContain('<p>hello</p>');
 	});
 
 	test('writes the original document when no rung matches (outcome=fallback)', async () => {
@@ -97,6 +205,7 @@ describe('extractPages', () => {
 			session: FAKE_SESSION,
 			items: [{ url: 'https://example.com/x' }],
 			outputDir,
+			contentClass: CONTENT_CLASS,
 			limit: 1,
 			onResult: (event) => results.push(event),
 		});
@@ -110,6 +219,8 @@ describe('extractPages', () => {
 		]);
 		const written = await readFile(path.join(outputDir, 'x.html'), 'utf8');
 		expect(written).toBe(`---\nid: 5\n---\n${original}`);
+		// No main was found, so block conversion is never attempted.
+		expect(resolvePageLayoutsMock).not.toHaveBeenCalled();
 	});
 
 	test('emits outcome=missing without writing to disk when archive returns null', async () => {
@@ -120,6 +231,7 @@ describe('extractPages', () => {
 			session: FAKE_SESSION,
 			items: [{ url: 'https://example.com/nope' }],
 			outputDir,
+			contentClass: CONTENT_CLASS,
 			limit: 1,
 			onResult: (event) => results.push(event),
 		});
@@ -136,6 +248,7 @@ describe('extractPages', () => {
 			session: FAKE_SESSION,
 			items: [{ url: 'https://example.com/x' }],
 			outputDir,
+			contentClass: CONTENT_CLASS,
 			limit: 1,
 			onResult: (event) => results.push(event),
 		});
@@ -153,6 +266,7 @@ describe('extractPages', () => {
 			session: FAKE_SESSION,
 			items: [],
 			outputDir,
+			contentClass: CONTENT_CLASS,
 			limit: 1,
 		});
 		expect(getPageHtmlMock).not.toHaveBeenCalled();
@@ -171,6 +285,7 @@ describe('extractPages', () => {
 				{ url: 'https://example.com/about/index.html' },
 			],
 			outputDir,
+			contentClass: CONTENT_CLASS,
 			limit: 2,
 			onResult: (event) => results.push(event),
 		});
@@ -180,7 +295,10 @@ describe('extractPages', () => {
 		const failed = results.find(
 			(event) => event.url === 'https://example.com/about/index.html',
 		);
-		expect(extracted).toMatchObject({ outcome: 'extracted' });
+		expect(extracted).toMatchObject({
+			outcome: 'extracted',
+			blockConversion: 'converted',
+		});
 		expect(failed).toMatchObject({
 			outcome: 'failed',
 			error: { message: expect.stringMatching(/duplicate output path/i) },
@@ -199,13 +317,16 @@ describe('extractPages', () => {
 			session: FAKE_SESSION,
 			items: [{ url: 'https://example.com/p' }],
 			outputDir,
+			contentClass: CONTENT_CLASS,
 			limit: 1,
 		});
 
 		const written = await readFile(path.join(outputDir, 'p.html'), 'utf8');
-		expect(written).toBe(
-			'---\nid: 5\ntitle: "Page"\nog:\n  title: "OG Page"\n---\n<main><p>body</p></main>',
-		);
+		expect(
+			written.startsWith(
+				`---\nid: 5\ntitle: "Page"\nog:\n  title: "OG Page"\n---\n<main class="${CONTENT_CLASS}">`,
+			),
+		).toBe(true);
 	});
 
 	test('prepends frontmatter even when extractMainContent falls back to the full document', async () => {
@@ -218,6 +339,7 @@ describe('extractPages', () => {
 			session: FAKE_SESSION,
 			items: [{ url: 'https://example.com/p' }],
 			outputDir,
+			contentClass: CONTENT_CLASS,
 			limit: 1,
 			onResult: (event) => results.push(event),
 		});
@@ -235,11 +357,14 @@ describe('extractPages', () => {
 			session: FAKE_SESSION,
 			items: [{ url: 'https://example.com/p' }],
 			outputDir,
+			contentClass: CONTENT_CLASS,
 			limit: 1,
 		});
 
 		const written = await readFile(path.join(outputDir, 'p.html'), 'utf8');
-		expect(written).toBe('---\nid: 5\n---\n<main><p>x</p></main>');
+		expect(written.startsWith(`---\nid: 5\n---\n<main class="${CONTENT_CLASS}">`)).toBe(
+			true,
+		);
 	});
 
 	test('fails soft when getFrontmatter errors: the id-only frontmatter is still emitted', async () => {
@@ -254,6 +379,7 @@ describe('extractPages', () => {
 			session: FAKE_SESSION,
 			items: [{ url: 'https://example.com/p' }],
 			outputDir,
+			contentClass: CONTENT_CLASS,
 			limit: 1,
 			onResult: (event) => results.push(event),
 		});
@@ -262,15 +388,21 @@ describe('extractPages', () => {
 		expect(results[0]).toMatchObject({
 			url: 'https://example.com/p',
 			outcome: 'extracted',
+			metaError: { message: 'db boom' },
 		});
 		const written = await readFile(path.join(outputDir, 'p.html'), 'utf8');
-		expect(written).toBe('---\nid: 5\n---\n<main><p>x</p></main>');
+		expect(written.startsWith(`---\nid: 5\n---\n<main class="${CONTENT_CLASS}">`)).toBe(
+			true,
+		);
 	});
 
 	test('rewrites same-origin <a href> to the id template using the items-derived id map', async () => {
 		getPageHtmlMock.mockResolvedValueOnce(
 			docWith('<main><a href="/about/">about</a></main>'),
 		);
+		// Route the same href through the mocked block so the merged body (what
+		// rewritePageRefs actually runs against) contains it.
+		mockConvertedLayout('<a href="/about/">about</a>');
 
 		await extractPages({
 			session: FAKE_SESSION,
@@ -279,18 +411,21 @@ describe('extractPages', () => {
 				{ url: 'https://example.com/about/' },
 			],
 			outputDir,
+			contentClass: CONTENT_CLASS,
 			limit: 2,
 		});
 
 		const written = await readFile(path.join(outputDir, 'index.html'), 'utf8');
 		// `/index.html` is root section → id 5, `/about/` is subdir section 1 → id 10000.
-		expect(written).toBe('---\nid: 5\n---\n<main><a href="{{10000}}">about</a></main>');
+		expect(written).toContain('{{10000}}');
+		expect(written).not.toContain('href="/about/"');
 	});
 
 	test('fail-soft on rewritePageRefs throw: writes pre-rewrite HTML and surfaces rewriteError on the outcome', async () => {
 		getPageHtmlMock.mockResolvedValueOnce(
 			docWith('<main><a href="/about/">about</a></main>'),
 		);
+		mockConvertedLayout('<a href="/about/">about</a>');
 		rewritePageRefsMock.mockRejectedValueOnce(new Error('parse5 boom'));
 
 		const results: ExtractPageResult[] = [];
@@ -298,6 +433,7 @@ describe('extractPages', () => {
 			session: FAKE_SESSION,
 			items: [{ url: 'https://example.com/p' }],
 			outputDir,
+			contentClass: CONTENT_CLASS,
 			limit: 1,
 			onResult: (event) => results.push(event),
 		});
@@ -309,8 +445,9 @@ describe('extractPages', () => {
 			rewriteError: { message: 'parse5 boom' },
 		});
 		const written = await readFile(path.join(outputDir, 'p.html'), 'utf8');
-		// Body is the un-rewritten extracted fragment (no {{id}} substitution).
-		expect(written).toBe('---\nid: 5\n---\n<main><a href="/about/">about</a></main>');
+		// Body is the un-rewritten merged fragment (no {{id}} substitution).
+		expect(written).toContain('href="/about/"');
+		expect(written).not.toContain('{{');
 	});
 
 	test('surfaces getFrontmatter rejection as metaError on the outcome (id-only frontmatter still written)', async () => {
@@ -322,6 +459,7 @@ describe('extractPages', () => {
 			session: FAKE_SESSION,
 			items: [{ url: 'https://example.com/p' }],
 			outputDir,
+			contentClass: CONTENT_CLASS,
 			limit: 1,
 			onResult: (event) => results.push(event),
 		});
@@ -337,16 +475,18 @@ describe('extractPages', () => {
 		getPageHtmlMock.mockResolvedValueOnce(
 			docWith('<main><img src="../img/a.png"></main>'),
 		);
+		mockConvertedLayout('<img src="../img/a.png">');
 
 		await extractPages({
 			session: FAKE_SESSION,
 			items: [{ url: 'https://example.com/sub/page.html' }],
 			outputDir,
+			contentClass: CONTENT_CLASS,
 			limit: 1,
 		});
 
 		const written = await readFile(path.join(outputDir, 'sub', 'page.html'), 'utf8');
-		expect(written).toBe('---\nid: 10000\n---\n<main><img src="/img/a.png"></main>');
+		expect(written).toContain('src="/img/a.png"');
 	});
 
 	test('returns immediately and writes nothing when signal is already aborted', async () => {
@@ -358,6 +498,7 @@ describe('extractPages', () => {
 			session: FAKE_SESSION,
 			items: [{ url: 'https://example.com/x' }],
 			outputDir,
+			contentClass: CONTENT_CLASS,
 			limit: 1,
 			signal: controller.signal,
 			onResult: (event) => results.push(event),
@@ -366,5 +507,276 @@ describe('extractPages', () => {
 		expect(results).toEqual([]);
 		expect(getPageHtmlMock).not.toHaveBeenCalled();
 		await expect(readFile(path.join(outputDir, 'x.html'))).rejects.toThrow();
+	});
+
+	describe('BurgerEditorブロック変換パイプライン', () => {
+		test('resolvePageLayoutsを一括で1回だけ呼び、複数の一致ページをまとめて処理する', async () => {
+			getPageHtmlMock.mockResolvedValueOnce(docWith('<main><p>a</p></main>'));
+			getPageHtmlMock.mockResolvedValueOnce(docWith('<main><p>b</p></main>'));
+
+			await extractPages({
+				session: FAKE_SESSION,
+				items: [{ url: 'https://example.com/a' }, { url: 'https://example.com/b' }],
+				outputDir,
+				contentClass: CONTENT_CLASS,
+				limit: 2,
+			});
+
+			expect(resolvePageLayoutsMock).toHaveBeenCalledTimes(1);
+			const call = resolvePageLayoutsMock.mock.calls[0]![0];
+			expect(call.items.map((item) => item.url).toSorted()).toEqual([
+				'https://example.com/a',
+				'https://example.com/b',
+			]);
+		});
+
+		test('layoutJsonPathをresolvePageLayoutsへそのまま転送する', async () => {
+			getPageHtmlMock.mockResolvedValueOnce(docWith('<main><p>a</p></main>'));
+
+			await extractPages({
+				session: FAKE_SESSION,
+				items: [{ url: 'https://example.com/a' }],
+				outputDir,
+				contentClass: CONTENT_CLASS,
+				layoutJsonPath: '/tmp/layout.jsonl',
+				limit: 1,
+			});
+
+			expect(resolvePageLayoutsMock).toHaveBeenCalledWith(
+				expect.objectContaining({ layoutJsonPath: '/tmp/layout.jsonl' }),
+			);
+		});
+
+		test('一部ブロックが低信頼度でwysiwygフォールバックされた場合はblockConversion=partialになる', async () => {
+			getPageHtmlMock.mockResolvedValueOnce(docWith('<main><p>x</p></main>'));
+			resolvePageLayoutsMock.mockImplementation((options) => {
+				for (const item of options.items) {
+					options.onResult?.({
+						url: item.url,
+						outcome: 'resolved-live',
+						results: [
+							{
+								url: item.url,
+								viewport: { name: 'pc', width: 1280 },
+								mainSelector: 'main',
+								root: {
+									...sampleLeafBlock(),
+									layoutType: 'vertical-stack',
+									confidence: 1,
+									children: [
+										{
+											...sampleLeafBlock(),
+											layoutType: 'simple-grid',
+											confidence: 0.9,
+											// rowSizes合計(3) !== children.length(1) → malformed-row-sizes
+											signals: { rowSizes: [3] },
+											children: [sampleLeafBlock()],
+										},
+									],
+								},
+							},
+						],
+					});
+				}
+				return Promise.resolve();
+			});
+
+			const results: ExtractPageResult[] = [];
+			await extractPages({
+				session: FAKE_SESSION,
+				items: [{ url: 'https://example.com/p' }],
+				outputDir,
+				contentClass: CONTENT_CLASS,
+				limit: 1,
+				onResult: (event) => results.push(event),
+			});
+
+			expect(results[0]).toMatchObject({
+				outcome: 'extracted',
+				blockConversion: 'partial',
+			});
+		});
+
+		test('resolvePageLayoutsが致命的に失敗した場合はページ全体をプレーンHTMLでフォールバックする', async () => {
+			const original = docWith('<main><p>hello</p></main>');
+			getPageHtmlMock.mockResolvedValueOnce(original);
+			mockMissingLayout('getaddrinfo ENOTFOUND');
+
+			const results: ExtractPageResult[] = [];
+			await extractPages({
+				session: FAKE_SESSION,
+				items: [{ url: 'https://example.com/p' }],
+				outputDir,
+				contentClass: CONTENT_CLASS,
+				limit: 1,
+				onResult: (event) => results.push(event),
+			});
+
+			expect(results[0]).toMatchObject({
+				outcome: 'extracted',
+				blockConversion: 'fallback',
+				blockConversionError: { message: 'getaddrinfo ENOTFOUND' },
+			});
+			const written = await readFile(path.join(outputDir, 'p.html'), 'utf8');
+			expect(written).toBe(`---\nid: 5\n---\n${original}`);
+		});
+
+		test('anatomistのmainSelectorとextractMainContentのマッチが不整合な場合はページ全体をフォールバックする', async () => {
+			const original = docWith('<main><p>hello</p></main><section></section>');
+			getPageHtmlMock.mockResolvedValueOnce(original);
+			resolvePageLayoutsMock.mockImplementation((options) => {
+				for (const item of options.items) {
+					options.onResult?.({
+						url: item.url,
+						outcome: 'resolved-live',
+						results: [
+							{
+								url: item.url,
+								viewport: { name: 'pc', width: 1280 },
+								// extractMainContentは<main>を選ぶが、anatomistは<section>を指している。
+								mainSelector: 'section',
+								root: {
+									...sampleLeafBlock(),
+									layoutType: 'vertical-stack',
+									confidence: 1,
+									children: [sampleLeafBlock()],
+								},
+							},
+						],
+					});
+				}
+				return Promise.resolve();
+			});
+
+			const results: ExtractPageResult[] = [];
+			await extractPages({
+				session: FAKE_SESSION,
+				items: [{ url: 'https://example.com/p' }],
+				outputDir,
+				contentClass: CONTENT_CLASS,
+				limit: 1,
+				onResult: (event) => results.push(event),
+			});
+
+			expect(results[0]).toMatchObject({
+				outcome: 'extracted',
+				blockConversion: 'fallback',
+			});
+			const written = await readFile(path.join(outputDir, 'p.html'), 'utf8');
+			expect(written).toBe(`---\nid: 5\n---\n${original}`);
+		});
+
+		test('anatomist側でmainのrootが見つからない(root:null)場合はページ全体をフォールバックする', async () => {
+			const original = docWith('<main><p>hello</p></main>');
+			getPageHtmlMock.mockResolvedValueOnce(original);
+			resolvePageLayoutsMock.mockImplementation((options) => {
+				for (const item of options.items) {
+					options.onResult?.({
+						url: item.url,
+						outcome: 'resolved-live',
+						results: [
+							{
+								url: item.url,
+								viewport: { name: 'pc', width: 1280 },
+								mainSelector: null,
+								root: null,
+							},
+						],
+					});
+				}
+				return Promise.resolve();
+			});
+
+			const results: ExtractPageResult[] = [];
+			await extractPages({
+				session: FAKE_SESSION,
+				items: [{ url: 'https://example.com/p' }],
+				outputDir,
+				contentClass: CONTENT_CLASS,
+				limit: 1,
+				onResult: (event) => results.push(event),
+			});
+
+			expect(results[0]).toMatchObject({
+				outcome: 'extracted',
+				blockConversion: 'fallback',
+			});
+		});
+
+		test('renderBlocksが例外を投げた場合はページ全体をフォールバックする', async () => {
+			const original = docWith('<main><p>hello</p></main>');
+			getPageHtmlMock.mockResolvedValueOnce(original);
+			renderBlocksMock.mockRejectedValueOnce(new Error('render boom'));
+
+			const results: ExtractPageResult[] = [];
+			await extractPages({
+				session: FAKE_SESSION,
+				items: [{ url: 'https://example.com/p' }],
+				outputDir,
+				contentClass: CONTENT_CLASS,
+				limit: 1,
+				onResult: (event) => results.push(event),
+			});
+
+			expect(results[0]).toMatchObject({
+				outcome: 'extracted',
+				blockConversion: 'fallback',
+				blockConversionError: { message: 'render boom' },
+			});
+			const written = await readFile(path.join(outputDir, 'p.html'), 'utf8');
+			expect(written).toBe(`---\nid: 5\n---\n${original}`);
+		});
+
+		test('resolvePageLayoutsが一致したURLについて結果を1件も返さない場合もページ全体をフォールバックする', async () => {
+			const original = docWith('<main><p>hello</p></main>');
+			getPageHtmlMock.mockResolvedValueOnce(original);
+			// Misbehaving mock: never calls onResult for the URL it was given.
+			resolvePageLayoutsMock.mockImplementation(() => Promise.resolve());
+
+			const results: ExtractPageResult[] = [];
+			await extractPages({
+				session: FAKE_SESSION,
+				items: [{ url: 'https://example.com/p' }],
+				outputDir,
+				contentClass: CONTENT_CLASS,
+				limit: 1,
+				onResult: (event) => results.push(event),
+			});
+
+			expect(results[0]).toMatchObject({
+				outcome: 'extracted',
+				blockConversion: 'fallback',
+			});
+			const written = await readFile(path.join(outputDir, 'p.html'), 'utf8');
+			expect(written).toBe(`---\nid: 5\n---\n${original}`);
+		});
+
+		test('resolvePageLayoutsが空のresults配列を返した場合もページ全体をフォールバックする', async () => {
+			const original = docWith('<main><p>hello</p></main>');
+			getPageHtmlMock.mockResolvedValueOnce(original);
+			resolvePageLayoutsMock.mockImplementation((options) => {
+				for (const item of options.items) {
+					options.onResult?.({ url: item.url, outcome: 'resolved-live', results: [] });
+				}
+				return Promise.resolve();
+			});
+
+			const results: ExtractPageResult[] = [];
+			await extractPages({
+				session: FAKE_SESSION,
+				items: [{ url: 'https://example.com/p' }],
+				outputDir,
+				contentClass: CONTENT_CLASS,
+				limit: 1,
+				onResult: (event) => results.push(event),
+			});
+
+			expect(results[0]).toMatchObject({
+				outcome: 'extracted',
+				blockConversion: 'fallback',
+			});
+			const written = await readFile(path.join(outputDir, 'p.html'), 'utf8');
+			expect(written).toBe(`---\nid: 5\n---\n${original}`);
+		});
 	});
 });

--- a/packages/@d-zero/site-migrator/src/page-extractor/extract-pages.ts
+++ b/packages/@d-zero/site-migrator/src/page-extractor/extract-pages.ts
@@ -1,5 +1,7 @@
+import type { DownloadResult } from '../downloader/download-resources.js';
 import type { ExtractMainCriterion } from '../html/extract-main-content.js';
-import type { ArchiveSession } from '../types.js';
+import type { ArchiveSession, Frontmatter } from '../types.js';
+import type { BlockData } from '@burger-editor/core';
 
 import { mkdir, writeFile } from 'node:fs/promises';
 import path from 'node:path';
@@ -11,8 +13,21 @@ import { getPageHtml } from '../archive/get-page-html.js';
 import { urlToOutputPath } from '../downloader/url-to-output-path.js';
 import { extractMainContent } from '../html/extract-main-content.js';
 import { formatFrontmatter } from '../html/format-frontmatter.js';
+import { mergeMainContent } from '../html/merge-main-content.js';
 
 import { assignPageIds } from './assign-page-ids.js';
+import { isMainConsistent } from './check-main-consistency.js';
+import { downloadBlockFiles } from './download-block-files.js';
+import {
+	DEFAULT_PRIMARY_VIEWPORT_NAME,
+	layoutToBlockData,
+	selectPrimary,
+} from './layout-to-block-data.js';
+import { renderBlocks } from './render-blocks.js';
+import {
+	resolvePageLayouts,
+	type ResolvePageLayoutResult,
+} from './resolve-page-layout.js';
 import { buildPageIdLookup, rewritePageRefs } from './rewrite-page-refs.js';
 
 /**
@@ -27,9 +42,32 @@ export interface ExtractPagesOptions {
 	session: ArchiveSession;
 	items: readonly ExtractPageItem[];
 	outputDir: string;
-	/** Maximum concurrent page extractions. Defaults to 10. */
+	/**
+	 * BurgerEditorの`editableArea`セレクタに対応させるクラス名。生成したブロック群を
+	 * 埋め込む既存main要素自身の`classList`に追加する（新規ラッパー要素は追加しない）。
+	 * 移行先サイトのBurgerEditor設定に依存する値であり、決め打ちのデフォルトを持たせると
+	 * 気づかれないまま不整合な出力を生成しうるため必須。
+	 */
+	contentClass: string;
+	/**
+	 * 事前生成済みのanatomistレイアウト解析JSONL（1ファイルで対象URL全件分）。
+	 * {@link resolvePageLayouts}にそのまま転送される。省略時は全ページをライブ解析する。
+	 */
+	layoutJsonPath?: string;
+	/**
+	 * 通常のリソースDL（`listInternalResources`由来）で既にカバー済みの絶対URL集合。
+	 * ブロック内`download-file`アイテムの実DL時、二重ダウンロードを避けるために使う。
+	 * 省略時は空集合（＝すべてのdownload-file候補を新規DL対象とみなす）。
+	 */
+	knownResourceUrls?: ReadonlySet<string>;
+	/**
+	 * Maximum concurrent page extractions. `resolvePageLayouts`の並列数（ライブレイアウト
+	 * 解析の並列数）にも同じ値を転送する（専用オプションは設けない）。Defaults to 10.
+	 */
 	limit?: number;
 	onResult?: (event: ExtractPageResult) => void;
+	/** ブロック内download-fileアイテムの追加DL進捗。`downloadResources`と同じイベント形。 */
+	onResource?: (event: DownloadResult) => void;
 	signal?: AbortSignal;
 }
 
@@ -39,6 +77,15 @@ export type ExtractPageResult =
 			outcome: 'extracted';
 			outputPath: string;
 			matchedBy: ExtractMainCriterion;
+			/**
+			 * ブロック単位の変換結果。`converted`=全ブロックが構造変換に成功、`partial`=
+			 * 一部ブロックのみ低信頼度でwysiwygフォールバックされたが致命的ではない、
+			 * `fallback`=致命的エラーによりページ全体がプレーンHTML（`data-bge-*`マーカー
+			 * 無し）のまま出力された。
+			 */
+			blockConversion: 'converted' | 'partial' | 'fallback';
+			/** `blockConversion`が`fallback`のときのみセットされる致命的エラー。 */
+			blockConversionError?: Error;
 			/**
 			 * Present only when {@link rewritePageRefs} threw. The page body was
 			 * still written (fail-soft), but with original asset / page references
@@ -72,15 +119,60 @@ export type ExtractPageResult =
 	  };
 
 /**
+ * ページ単位の致命的ブロック変換エラー（main検出はできたが、それ以降のパイプラインで
+ * 復旧不能なエラーが起きた）を表す。この場合は{@link BlockOutcome}全体を諦め、呼び出し側が
+ * ページ全体をプレーンHTMLとして書き出す。
+ */
+interface FatalBlockOutcome {
+	readonly kind: 'fatal';
+	readonly error: Error;
+}
+
+interface ResolvedBlockOutcome {
+	readonly kind: 'converted' | 'partial';
+	readonly blocks: BlockData[];
+}
+
+type BlockOutcome = FatalBlockOutcome | ResolvedBlockOutcome;
+
+/**
  * For each page URL, reads the HTML snapshot from the archive, strips the
  * shared layout via {@link extractMainContent}, reads the per-page metadata
- * from the `.nitpicker` DB via {@link getFrontmatter}, rewrites same-origin
- * URL references via {@link rewritePageRefs}, and writes the result to disk
- * under `outputDir` mirroring the URL pathname.
+ * from the `.nitpicker` DB via {@link getFrontmatter}, converts the page's
+ * anatomist layout analysis into BurgerEditor blocks (see below), rewrites
+ * same-origin URL references via {@link rewritePageRefs}, and writes the
+ * result to disk under `outputDir` mirroring the URL pathname.
  *
  * Mirrors {@link import('../downloader/download-resources.js').downloadResources}
  * in shape: failures (including pages absent from the archive) are surfaced via
  * `onResult`, never thrown, so a single bad page does not abort the run.
+ *
+ * ## BurgerEditorブロック変換パイプライン（親Issue #977）
+ *
+ * 全ページの`getPageHtml`+`extractMainContent`+`getFrontmatter`を並列実行し、
+ * main要素が見つかったページ（`extracted`候補）と見つからなかったページ（`fallback`）を
+ * 仕分ける。main候補となった全URLはまとめて**1回**の{@link resolvePageLayouts}呼び出しに
+ * 渡す — ページごとに呼ぶとPuppeteerブラウザをページ数だけlaunch/closeすることになり
+ * 実運用サイト規模では致命的に遅くなるため、ブラウザを1回だけ起動して使い回す。続けて
+ * 各ページについて{@link layoutToBlockData}でBurgerEditorの`BlockData[]`へ変換し、
+ * {@link renderBlocks}で`data-bge-*`付きHTMLへ変換し、{@link mergeMainContent}で
+ * ラッパー要素を挟まずに既存main要素へ埋め込み、`rewritePageRefs`→frontmatter→
+ * 書き出し、という既存の後段パイプラインへ合流させる。
+ *
+ * ### ページ単位の致命的フォールバック
+ *
+ * 以下のいずれかに該当する場合、そのページのブロック変換は諦め、`blockConversion:
+ * 'fallback'`として**ページ全体の元の完全なHTML**（`data-bge-*`マーカー無し）を書き出す
+ * （品質判断によるページ全体フォールバックは行わない — 個別ブロックの低信頼度は
+ * `blockConversion: 'partial'`として扱い、ページ全体は諦めない）:
+ *
+ * - {@link resolvePageLayouts}がそのページについて完全に失敗した（`missing` outcome。
+ *   ライブURL到達不可等）
+ * - anatomistの`mainSelector`と`extractMainContent`がマッチした要素が一致しない
+ *   （{@link isMainConsistent}による簡易判定。厳密な整合化は#978の責務）
+ * - {@link layoutToBlockData}が空の`blocks`を返した（anatomist側で`root`が
+ *   見つからなかった — mainは検出できたがブロック化できる構造が無い）
+ * - {@link renderBlocks}または{@link mergeMainContent}が例外を投げた
  *
  * Output layout per file:
  *
@@ -88,12 +180,15 @@ export type ExtractPageResult =
  *   the page's integer `id` assigned by {@link assignPageIds}, plus any
  *   non-empty meta from the DB. The id is the only mandatory field.
  * - The body that follows depends on the outcome:
- *   - `extracted` — the matched element's `outerHTML` fragment.
- *   - `fallback` — the entire original document, DOCTYPE included.
+ *   - `extracted`（`blockConversion: 'converted'`/`'partial'`）— main要素の`outerHTML`
+ *     フラグメント。子要素はBurgerEditorブロック群に置き換わり、`contentClass`が
+ *     main要素自身の`classList`に追加されている。
+ *   - `extracted`（`blockConversion: 'fallback'`）／`fallback` — the entire original
+ *     document, DOCTYPE included.
  * - In both cases same-origin URLs are rewritten: `<a href>` / `<form action>`
  *   pointing at a known page → `{{<id>}}<query><fragment>`; other same-origin
  *   asset references → root-relative paths. Cross-origin URLs are left
- *   untouched.
+ *   untouched. 生成したブロック内のURL自体の書き換えは対象外（#979の責務）。
  *
  * Rewrite failure is fail-soft: the original HTML body is written and
  * `rewriteError` is set on the result so the caller can log a warning without
@@ -101,7 +196,18 @@ export type ExtractPageResult =
  * @param options
  */
 export async function extractPages(options: ExtractPagesOptions): Promise<void> {
-	const { session, items, outputDir, limit = 10, onResult, signal } = options;
+	const {
+		session,
+		items,
+		outputDir,
+		contentClass,
+		layoutJsonPath,
+		knownResourceUrls = new Set(),
+		limit = 10,
+		onResult,
+		onResource,
+		signal,
+	} = options;
 	if (items.length === 0 || signal?.aborted) {
 		// Short-circuit when the signal is already aborted (e.g. SIGINT during
 		// the preceding download phase) so we don't litter outputDir with
@@ -135,11 +241,7 @@ export async function extractPages(options: ExtractPagesOptions): Promise<void> 
 			seenPaths.add(outputPath);
 			return { url: item.url, outputPath, resolveError: null };
 		} catch (error) {
-			return {
-				url: item.url,
-				outputPath: '',
-				resolveError: error instanceof Error ? error : new Error(String(error)),
-			};
+			return { url: item.url, outputPath: '', resolveError: toError(error) };
 		}
 	});
 
@@ -159,15 +261,23 @@ export async function extractPages(options: ExtractPagesOptions): Promise<void> 
 	const pageIds = assignPageIds(items.map((item) => item.url));
 	const pageIdLookup = buildPageIdLookup(pageIds);
 
+	// --- Fetch + extractMainContent + meta, per page, concurrent ---
+	interface PageExtractState {
+		readonly entry: PreparedPage;
+		readonly originalHtml: string;
+		readonly matched: boolean;
+		readonly matchedBy?: ExtractMainCriterion;
+		readonly extractedHtml: string;
+		readonly meta: Frontmatter | null;
+		readonly metaError?: Error;
+	}
+	const extractedByUrl = new Map<string, PageExtractState>();
+
 	await deal(
 		prepared,
 		(entry) => async () => {
 			if (entry.resolveError !== null) {
-				onResult?.({
-					url: entry.url,
-					outcome: 'failed',
-					error: entry.resolveError,
-				});
+				onResult?.({ url: entry.url, outcome: 'failed', error: entry.resolveError });
 				return;
 			}
 			try {
@@ -189,67 +299,277 @@ export async function extractPages(options: ExtractPagesOptions): Promise<void> 
 					return;
 				}
 				const extracted = extractMainContent(html);
-				const id = pageIds.get(entry.url);
-
-				let bodyHtml = extracted.html;
-				let rewriteError: Error | undefined;
-				try {
-					bodyHtml = await rewritePageRefs({
-						html: extracted.html,
-						baseUrl: entry.url,
-						pageIdLookup,
-					});
-				} catch (error) {
-					rewriteError = error instanceof Error ? error : new Error(String(error));
-				}
-
+				// `matchedBy` is only ever `undefined` when `matched` is `false` in
+				// practice, but `ExtractMainResult`'s type doesn't encode that —
+				// treat the pair as the single source of truth for "did we
+				// actually find a main candidate".
+				const matched = extracted.matched && extracted.matchedBy !== undefined;
 				const meta = metaSettled.status === 'fulfilled' ? metaSettled.value : null;
 				const metaError =
-					metaSettled.status === 'rejected'
-						? metaSettled.reason instanceof Error
-							? metaSettled.reason
-							: new Error(String(metaSettled.reason))
-						: undefined;
-				// Spread `meta` first so the computed integer id always wins over a
-				// stray `id` field the DB might one day surface — keeping the
-				// frontmatter id consistent with the {{<id>}} tokens rewritePageRefs
-				// emits on peer pages.
-				const frontmatterMeta = id === undefined ? meta : { ...meta, id };
-				// `frontmatterMeta === null` only happens when assignPageIds dropped
-				// the URL (unparsable) AND getFrontmatter returned no row; the page
-				// is still written body-only so downstream callers can decide what
-				// to do with the orphan.
-				const frontmatterBlock =
-					frontmatterMeta === null ? '' : formatFrontmatter(frontmatterMeta);
-
-				await writeFile(entry.outputPath, frontmatterBlock + bodyHtml, 'utf8');
-				const softErrors: { rewriteError?: Error; metaError?: Error } = {};
-				if (rewriteError) softErrors.rewriteError = rewriteError;
-				if (metaError) softErrors.metaError = metaError;
-				if (extracted.matched && extracted.matchedBy !== undefined) {
-					onResult?.({
-						url: entry.url,
-						outcome: 'extracted',
-						outputPath: entry.outputPath,
-						matchedBy: extracted.matchedBy,
-						...softErrors,
-					});
-				} else {
-					onResult?.({
-						url: entry.url,
-						outcome: 'fallback',
-						outputPath: entry.outputPath,
-						...softErrors,
-					});
-				}
-			} catch (error) {
-				onResult?.({
-					url: entry.url,
-					outcome: 'failed',
-					error: error instanceof Error ? error : new Error(String(error)),
+					metaSettled.status === 'rejected' ? toError(metaSettled.reason) : undefined;
+				extractedByUrl.set(entry.url, {
+					entry,
+					originalHtml: html,
+					matched,
+					matchedBy: matched ? extracted.matchedBy : undefined,
+					extractedHtml: extracted.html,
+					meta,
+					metaError,
 				});
+			} catch (error) {
+				onResult?.({ url: entry.url, outcome: 'failed', error: toError(error) });
 			}
 		},
 		{ limit, signal },
 	);
+
+	// --- Batch layout resolution: one resolvePageLayouts call for every
+	// matched URL, so the Puppeteer browser (when needed) launches once for
+	// the whole run instead of once per page. ---
+	const matchedStates = [...extractedByUrl.values()].filter((state) => state.matched);
+	const layoutResultsByUrl = new Map<string, ResolvePageLayoutResult>();
+	if (matchedStates.length > 0) {
+		await resolvePageLayouts({
+			items: matchedStates.map((state) => ({ url: state.entry.url })),
+			layoutJsonPath,
+			limit,
+			signal,
+			onResult: (event) => {
+				layoutResultsByUrl.set(event.url, event);
+			},
+		});
+	}
+
+	// --- Resolve each matched page's BlockData (or the fatal reason it
+	// can't be produced), independent of rendering. ---
+	const blockOutcomeByUrl = new Map<string, BlockOutcome>();
+	for (const state of matchedStates) {
+		blockOutcomeByUrl.set(
+			state.entry.url,
+			resolveBlockOutcome(state, layoutResultsByUrl),
+		);
+	}
+
+	// --- download-file dedupe + real DL, batched across every page that has a
+	// usable BlockData tree (fatal pages have nothing to scan). ---
+	const blocksByUrl = new Map<string, readonly BlockData[]>();
+	for (const [url, outcome] of blockOutcomeByUrl) {
+		if (outcome.kind !== 'fatal') {
+			blocksByUrl.set(url, outcome.blocks);
+		}
+	}
+	if (blocksByUrl.size > 0) {
+		await downloadBlockFiles({
+			blocksByUrl,
+			outputDir,
+			knownResourceUrls,
+			limit,
+			onResult: onResource,
+			signal,
+		});
+	}
+
+	// --- Render + merge + rewrite + frontmatter + write, per page. ---
+	await deal(
+		[...extractedByUrl.values()],
+		(state) => async () => {
+			const { entry } = state;
+			try {
+				if (!state.matched) {
+					let bodyHtml = state.extractedHtml;
+					let rewriteError: Error | undefined;
+					try {
+						bodyHtml = await rewritePageRefs({
+							html: state.extractedHtml,
+							baseUrl: entry.url,
+							pageIdLookup,
+						});
+					} catch (error) {
+						rewriteError = toError(error);
+					}
+					await writeFile(
+						entry.outputPath,
+						buildFrontmatterBlock(state, pageIds) + bodyHtml,
+						'utf8',
+					);
+					onResult?.({
+						url: entry.url,
+						outcome: 'fallback',
+						outputPath: entry.outputPath,
+						...(rewriteError ? { rewriteError } : {}),
+						...(state.metaError ? { metaError: state.metaError } : {}),
+					});
+					return;
+				}
+
+				const blockOutcome = blockOutcomeByUrl.get(entry.url)!;
+				const built = await buildExtractedBody(state, blockOutcome, contentClass);
+
+				let bodyHtml = built.body;
+				let rewriteError: Error | undefined;
+				try {
+					bodyHtml = await rewritePageRefs({
+						html: built.body,
+						baseUrl: entry.url,
+						pageIdLookup,
+					});
+				} catch (error) {
+					rewriteError = toError(error);
+				}
+
+				await writeFile(
+					entry.outputPath,
+					buildFrontmatterBlock(state, pageIds) + bodyHtml,
+					'utf8',
+				);
+				onResult?.({
+					url: entry.url,
+					outcome: 'extracted',
+					outputPath: entry.outputPath,
+					matchedBy: state.matchedBy!,
+					blockConversion: built.blockConversion,
+					...(built.blockConversionError
+						? { blockConversionError: built.blockConversionError }
+						: {}),
+					...(rewriteError ? { rewriteError } : {}),
+					...(state.metaError ? { metaError: state.metaError } : {}),
+				});
+			} catch (error) {
+				onResult?.({ url: entry.url, outcome: 'failed', error: toError(error) });
+			}
+		},
+		{ limit, signal },
+	);
+}
+
+/**
+ * `resolvePageLayouts`の結果と`extractMainContent`の結果から、そのページのブロック変換が
+ * 続行可能かを判定する。続行不能（致命的）と判定した場合は理由を`Error`として保持する。
+ * @param state
+ * @param state.entry
+ * @param state.entry.url
+ * @param state.originalHtml
+ * @param state.extractedHtml
+ * @param layoutResultsByUrl
+ */
+function resolveBlockOutcome(
+	state: {
+		readonly entry: { readonly url: string };
+		readonly originalHtml: string;
+		readonly extractedHtml: string;
+	},
+	layoutResultsByUrl: ReadonlyMap<string, ResolvePageLayoutResult>,
+): BlockOutcome {
+	const layoutEvent = layoutResultsByUrl.get(state.entry.url);
+	if (!layoutEvent) {
+		return {
+			kind: 'fatal',
+			error: new Error('resolvePageLayouts produced no result for this URL'),
+		};
+	}
+	if (layoutEvent.outcome === 'missing') {
+		return { kind: 'fatal', error: layoutEvent.error };
+	}
+
+	const { results } = layoutEvent;
+	const primary = selectPrimary(results, DEFAULT_PRIMARY_VIEWPORT_NAME);
+	if (
+		!isMainConsistent(
+			state.originalHtml,
+			state.extractedHtml,
+			primary?.mainSelector ?? null,
+		)
+	) {
+		return {
+			kind: 'fatal',
+			error: new Error(
+				'anatomist(mainSelector)とextractMainContentのmain要素検出結果が不整合です（簡易判定 — 厳密な整合化は#978）',
+			),
+		};
+	}
+
+	const { blocks, fallbacks } = layoutToBlockData(results);
+	if (blocks.length === 0) {
+		return {
+			kind: 'fatal',
+			error: new Error(
+				'レイアウト解析でブロック化可能なmain要素の子構造が見つかりませんでした',
+			),
+		};
+	}
+
+	return { kind: fallbacks.length > 0 ? 'partial' : 'converted', blocks };
+}
+
+/**
+ * `blockOutcome`から、rewritePageRefs適用前の本文HTMLと`blockConversion`分類を組み立てる。
+ * `renderBlocks`/`mergeMainContent`が例外を投げた場合もここでfatalとして扱い、ページ全体の
+ * 元の完全なHTMLへフォールバックする。
+ * @param state
+ * @param state.originalHtml
+ * @param state.extractedHtml
+ * @param blockOutcome
+ * @param contentClass
+ */
+async function buildExtractedBody(
+	state: { readonly originalHtml: string; readonly extractedHtml: string },
+	blockOutcome: BlockOutcome,
+	contentClass: string,
+): Promise<{
+	body: string;
+	blockConversion: 'converted' | 'partial' | 'fallback';
+	blockConversionError?: Error;
+}> {
+	if (blockOutcome.kind === 'fatal') {
+		return {
+			body: state.originalHtml,
+			blockConversion: 'fallback',
+			blockConversionError: blockOutcome.error,
+		};
+	}
+	try {
+		const wrapperHtml = await renderBlocks(blockOutcome.blocks, { contentClass });
+		const merged = mergeMainContent({
+			mainHtml: state.extractedHtml,
+			wrapperHtml,
+			contentClass,
+		});
+		return { body: merged, blockConversion: blockOutcome.kind };
+	} catch (error) {
+		return {
+			body: state.originalHtml,
+			blockConversion: 'fallback',
+			blockConversionError: toError(error),
+		};
+	}
+}
+
+/**
+ * @param state
+ * @param state.entry
+ * @param state.entry.url
+ * @param state.meta
+ * @param pageIds
+ */
+function buildFrontmatterBlock(
+	state: { readonly entry: { readonly url: string }; readonly meta: Frontmatter | null },
+	pageIds: ReadonlyMap<string, number>,
+): string {
+	const id = pageIds.get(state.entry.url);
+	// Spread `meta` first so the computed integer id always wins over a stray
+	// `id` field the DB might one day surface — keeping the frontmatter id
+	// consistent with the {{<id>}} tokens rewritePageRefs emits on peer pages.
+	const frontmatterMeta = id === undefined ? state.meta : { ...state.meta, id };
+	// `frontmatterMeta === null` only happens when assignPageIds dropped the
+	// URL (unparsable) AND getFrontmatter returned no row; the page is still
+	// written body-only so downstream callers can decide what to do with the
+	// orphan.
+	return frontmatterMeta === null ? '' : formatFrontmatter(frontmatterMeta);
+}
+
+/**
+ * @param error
+ */
+function toError(error: unknown): Error {
+	return error instanceof Error ? error : new Error(String(error));
 }

--- a/packages/@d-zero/site-migrator/src/page-extractor/layout-to-block-data.ts
+++ b/packages/@d-zero/site-migrator/src/page-extractor/layout-to-block-data.ts
@@ -20,7 +20,7 @@ export interface LayoutToBlockDataResult {
 	fallbacks: { blockIndex: number; reason: BlockFallbackReason }[];
 }
 
-const DEFAULT_PRIMARY_VIEWPORT_NAME = 'pc';
+export const DEFAULT_PRIMARY_VIEWPORT_NAME = 'pc';
 
 /**
  * コンテナ系`layoutType`（vertical-stack/horizontal-row/simple-grid/complex-grid/float-wrap）
@@ -112,10 +112,13 @@ export function layoutToBlockData(
 }
 
 /**
+ * `results`（同一URLの複数ビューポート分の解析結果）から、構造判定の主とするエントリを選ぶ。
+ * `layoutToBlockData`内部と、ページ単位フォールバック判定（#976の簡易anatomist不整合検出）の
+ * 両方から同じ選定ロジックを使うためexportしている。
  * @param results
  * @param primaryViewportName
  */
-function selectPrimary(
+export function selectPrimary(
 	results: readonly LayoutAnalysisResult[],
 	primaryViewportName: string,
 ): LayoutAnalysisResult | undefined {

--- a/packages/@d-zero/site-migrator/src/page-extractor/resolve-page-layout.spec.ts
+++ b/packages/@d-zero/site-migrator/src/page-extractor/resolve-page-layout.spec.ts
@@ -182,6 +182,23 @@ describe('resolvePageLayouts', () => {
 		expect(results[0]?.outcome).toBe('missing');
 	});
 
+	test('resolves (does not reject) when launch() itself fails — no Chrome binary / sandbox restrictions', async () => {
+		launchMock.mockRejectedValueOnce(new Error('spawn ENOENT'));
+
+		const results: ResolvePageLayoutResult[] = [];
+		await expect(
+			resolvePageLayouts({
+				items: [{ url: 'https://example.com/a' }, { url: 'https://example.com/b' }],
+				onResult: (event) => results.push(event),
+			}),
+		).resolves.toBeUndefined();
+
+		expect(results).toHaveLength(2);
+		for (const result of results) {
+			expect(result.outcome).toBe('missing');
+		}
+	});
+
 	test('does not hang and still reports the result when page.close() rejects during cleanup', async () => {
 		const page = {
 			close: vi.fn().mockRejectedValueOnce(new Error('Protocol error: Target closed')),

--- a/packages/@d-zero/site-migrator/src/page-extractor/resolve-page-layout.ts
+++ b/packages/@d-zero/site-migrator/src/page-extractor/resolve-page-layout.ts
@@ -203,8 +203,18 @@ export async function resolvePageLayouts(
 		);
 	} finally {
 		if (browserPromise !== undefined) {
-			const browser = await browserPromise;
-			await browser.close();
+			// Best-effort cleanup, mirroring the `page?.close()` handling above:
+			// `browserPromise` itself may be the *rejected* `launch()` promise
+			// (e.g. no Chrome binary / sandbox restrictions). Every per-item
+			// worker already reports that failure as `missing` and settles
+			// normally, so re-awaiting the same rejection here must not throw
+			// and take down the whole (otherwise fail-soft) run.
+			try {
+				const browser = await browserPromise;
+				await browser.close();
+			} catch {
+				/* ignore */
+			}
 		}
 	}
 }


### PR DESCRIPTION
## Summary

Closes #976. Integrates the previously-standalone BurgerEditor block conversion
pipeline (`resolvePageLayouts` / `layoutToBlockData` / `renderBlocks`, #973–#975)
into `extractPages`, `migrate`, and the `dz-migrate` CLI as default, non-opt-in
behavior, per the parent initiative (#977).

- `extractPages` now runs in two passes: extract main content for every page
  concurrently, then resolve layouts for every matched URL in a **single**
  batched `resolvePageLayouts` call (a Puppeteer browser launches once for the
  whole run, not once per page).
- New `mergeMainContent` (`src/html/`) splices the rendered block group into the
  existing `main` element's children without adding a wrapper element, and adds
  `--content-class` to `main`'s own `classList`.
- New `checkMainConsistency` (`isMainConsistent`) does a best-effort check that
  anatomist's `mainSelector` and `extractMainContent`'s match agree, as one of
  several page-level fatal-fallback triggers.
- New `downloadBlockFiles` dedupes and downloads block-referenced
  `download-file` items via the existing `downloadResources`, and reflects real
  file sizes back onto the item data.
- Each page's outcome is now classified as `blockConversion: 'converted' |
  'partial' | 'fallback'`. Block-level low-confidence never fails the whole
  page (`'partial'`); only fatal errors (layout resolution failure, main
  mismatch, no blocks produced, render/merge exception) fall back to the plain
  original document.
- `MigrateReport` gains `pagesBlockConverted` / `pagesBlockPartial` /
  `pagesBlockConversionFailed`; CLI output surfaces block conversion status per
  page and in the final summary.
- Fixed a pre-existing bug in `resolvePageLayouts`: a rejected Puppeteer
  `launch()` was re-awaited uncaught during cleanup, which would crash the
  whole run instead of failing soft per page — now reachable in production
  since this PR wires the function into the default pipeline.

**Breaking change** (package is `alpha`, no migration guide needed):
`extractPages`/`migrate`/`dz-migrate` now require a `contentClass` /
`--content-class` value — block conversion is mandatory, not opt-in, so there
is no sensible default (it must match the target site's BurgerEditor
`editableArea` selector).

## Test plan

- [x] `yarn build`
- [x] `yarn test` (245 tests, including new coverage for `mergeMainContent`,
      `isMainConsistent`, `downloadBlockFiles`, and every `blockConversion`
      outcome / fatal-fallback trigger in `extractPages`)
- [x] `yarn lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
