### PR TITLE
fix(site-migrator): rewrite same-origin refs in BurgerEditor blocks

### DIFF
--- a/packages/@d-zero/site-migrator/README.md
+++ b/packages/@d-zero/site-migrator/README.md
@@ -114,7 +114,7 @@ import {
 - それ以外のアセット属性（`<img src>`, `<img srcset>`, `<script src>`, `<source src/srcset>`, `<embed src>`, `<video src/poster>`, `<audio src>`, `<track src>`、および `<link>` の非ページ用法）は同一オリジンであれば root-relative path に書き換える。
 - id 写像のルックアップは origin+pathname+search の完全一致を先に試し、ヒットしなければ trailing-slash を吸収した origin+pathname にフォールバックする。これにより `/list?p=1` / `/list?p=2` の両方が `pageIds` に登録されていれば各々別の id に解決され、片方しか無ければ pathname-only の fallback で拾われる。`<a href="/about">` と `pageIds` の `/about/` も双方向にマッチする。
 
-`rewritePageRefs` が例外を投げた場合は fail-soft で書き換え前の HTML を出力し、`onResult` の `extracted` / `fallback` outcome に `rewriteError` フィールドを乗せてレポートする（`migrate()` の `pagesRewriteFailed` で集計）。フロントマター付与・id 採番は HTML 書き換えと独立して走るので、片方が失敗してももう片方は影響を受けない。
+`rewritePageRefs`（main 非検出・ブロック変換失敗ページ）または `rewriteBlockRefs`（ブロック変換成功ページ、詳細は後述）が失敗した場合は fail-soft で書き換え前の内容を出力し、`onResult` の `extracted` / `fallback` outcome に `rewriteError` フィールドを乗せてレポートする（`migrate()` の `pagesRewriteFailed` で集計）。フロントマター付与・id 採番は HTML 書き換えと独立して走るので、片方が失敗してももう片方は影響を受けない。
 
 ### `{{<id>}}` token の解決（後段ビルドツール）
 
@@ -143,6 +143,7 @@ import {
 | `resolvePageLayouts` | `--layout-json` の事前生成 JSONL を優先し、無ければ Puppeteer + `@d-zero/anatomist` でライブ解析する                                                                            |
 | `classifyBlockItem`  | anatomist の `LayoutBlock` 1 個を `image`/`title-h2`/`title-h3`/`youtube`/`google-maps`/`download-file`/`button`/`table`/`wysiwyg` へヒューリスティック分類する純関数           |
 | `layoutToBlockData`  | 複数ビューポート分の解析結果から `BlockData[]` を組み立てる純関数。ブロック単位の低信頼度は個別に `wysiwyg` へ倒し `fallbacks` に記録する                                       |
+| `rewriteBlockRefs`   | `BlockData[]` 内の同一オリジン URL を `renderBlocks` 前に書き換える（詳細は後述の専用節）                                                                                       |
 | `renderBlocks`       | `@burger-editor/core` の公式 `render()` で `BlockData[]` を `data-bge-*` 付き HTML へ変換する                                                                                   |
 | `mergeMainContent`   | `renderBlocks` のラッパー `<div>` の中身だけを既存 main 要素の子要素として差し替え、`--content-class` を main 要素自身の `classList` に追加する（新規ラッパー要素は追加しない） |
 | `isMainConsistent`   | anatomist の `mainSelector` と `extractMainContent` がマッチした要素の `outerHTML` を比較する簡易整合性チェック                                                                 |
@@ -152,7 +153,7 @@ import {
 
 1. `getPageHtml` + `extractMainContent` + `getFrontmatter` を全ページ分並列実行し、main が見つかったページ（ブロック変換対象）と見つからなかったページ（`outcome: 'fallback'`）を仕分ける。
 2. ブロック変換対象の全 URL をまとめて **1 回**の `resolvePageLayouts` 呼び出しに渡す（ページごとに呼ぶと Puppeteer ブラウザをページ数だけ起動することになり実運用サイト規模では致命的に遅くなるため）。
-3. ページごとに `isMainConsistent` → `layoutToBlockData` → `downloadBlockFiles`（バッチ） → `renderBlocks` → `mergeMainContent` → `rewritePageRefs` → frontmatter 付与 → 書き出し、という順で処理する。
+3. ページごとに `isMainConsistent` → `layoutToBlockData` → `downloadBlockFiles`（バッチ） → `rewriteBlockRefs` → `renderBlocks` → `mergeMainContent` → frontmatter 付与 → 書き出し、という順で処理する。ブロック変換に成功したページ（`converted`/`partial`）はこの時点で本文全体が書き換え済みのため、後段の `rewritePageRefs` は**適用しない**（適用すると `rewriteBlockRefs` が埋め込んだ `{{<id>}}` トークンを通常 URL として再解釈し文字化けする）。main 非検出・ブロック変換失敗（`fallback`）ページは元の HTML に `{{<id>}}` token が無いため、従来通り `rewritePageRefs` を適用する。
 
 #### ブロック単位フォールバックとページ単位フォールバックの区別
 
@@ -173,7 +174,7 @@ anatomist の `LayoutBlock`/`RawLayoutNode` は要素の属性（`href` / `src` 
 - 深さ圧縮（`BlockData.items` は「ブロック → 行×列 → item」の 2 階層まで）は、depth-2 ノードの `children` を一切読まず `classifyBlockItem` に丸投げすることで実現している。`classifyBlockItem` が `innerHTML` 文字列のみを見るため、depth-3 以降の `layoutType` 情報は自動的に破棄される。
 - `BlockData.name` は固定値 `'migrated'`（ブロックの見た目上の種別名は未確定のプレースホルダー）。
 - `render()` は内部で `document.createElement` / `new Range()` 等の DOM API に依存するため、初回呼び出し時のみ jsdom を起動して `globalThis` へ反映する（既に DOM 環境が存在する場合は何もしない）。
-- 生成したブロック内（wysiwyg の `<a href>`、image の `path` 等）の URL 自体は `rewritePageRefs` の対象外（既存 main 要素の外側にあった参照のみが書き換え対象）。ブロック内 URL への適用は将来の課題として切り出されている。
+- 生成したブロック内（wysiwyg の `<a href>`、`button.link`、`image.path[]`、`download-file.path`）の URL は `renderBlocks` 前に `rewriteBlockRefs` が書き換える（詳細は次節）。
 
 ### 出力先ライブラリ連携（`downloadBlockFiles`）
 
@@ -181,9 +182,10 @@ anatomist の `LayoutBlock`/`RawLayoutNode` は要素の属性（`href` / `src` 
 
 ### BurgerEditor ブロック内の同一オリジン参照書き換え（`rewriteBlockRefs`）
 
-`layoutToBlockData` が返す `BlockData[]` に含まれる同一オリジン URL（`wysiwyg` 内の `<a href>` 等、`button.link`、`image.path[]`、`download-file.path`）を、既存の `rewritePageRefs` と同じ正規化ルールで書き換える純関数（Issue #979）。`renderBlocks` を呼ぶ**前**、`BlockData` の段階で書き換える — レンダリング後の HTML 文字列に対して既存の `rewritePageRefs` をタグ名ベースで適用する方式だと、`button`/`download-file` アイテムはどちらも `<a href>` へレンダリングされ、両者を区別する `data-bgi` 属性が `<a>` 自身ではなく祖先要素に付与されるため、「button は page-ref 扱い（`{{<id>}}` 化あり）、download-file は asset 扱い（root-relative のみ）」を確実に区別できない。アイテム種別（`item.name`）が型として確定しているこの段階で書き換えることで、誤判定なく両者を区別する。`classifyBlockItem`/`layoutToBlockData`/`renderBlocks` 同様、統合前の内部 API のため `index.ts` からは export していない（`src/page-extractor/rewrite-block-refs.ts` を直接 import する）。統合先（`layoutToBlockData` → `rewriteBlockRefs` → `renderBlocks` の結線）は #976 で行う。
+`layoutToBlockData` が返す `BlockData[]` に含まれる同一オリジン URL（`wysiwyg` 内の `<a href>` 等、`button.link`、`image.path[]`、`download-file.path`）を、既存の `rewritePageRefs` と同じ正規化ルールで書き換える純関数（Issue #979）。`extractPages` が `renderBlocks` を呼ぶ**前**、`BlockData` の段階で書き換える — レンダリング後の HTML 文字列に対して既存の `rewritePageRefs` をタグ名ベースで適用する方式だと、`button`/`download-file` アイテムはどちらも `<a href>` へレンダリングされ、両者を区別する `data-bgi` 属性が `<a>` 自身ではなく祖先要素に付与されるため、「button は page-ref 扱い（`{{<id>}}` 化あり）、download-file は asset 扱い（root-relative のみ）」を確実に区別できない。アイテム種別（`item.name`）が型として確定しているこの段階で書き換えることで、誤判定なく両者を区別する。`classifyBlockItem`/`layoutToBlockData`/`renderBlocks` 同様、`index.ts` からは export していない内部 API（`src/page-extractor/rewrite-block-refs.ts` を直接 import する）。
 
 - `rewriteBlockRefs(options: { blocks: BlockData[], baseUrl: string, pageIdLookup: PageIdLookup }): Promise<{ blocks: BlockData[], errors: RewriteBlockRefsError[] }>` — `wysiwyg` は `rewritePageRefs` へそのまま委譲、`button.link` はページ参照ルール（既知ページなら `{{<id>}}` 化）、`image.path[]`/`download-file.path` はアセットルール（root-relative のみ、`{{<id>}}` 化はしない）、`google-maps`/`youtube` の `url` は外部オリジンのため対象外。`wysiwyg` の `rewritePageRefs` 呼び出しが失敗した場合は fail-soft で元の内容を保持し、`errors` に `{blockIndex, rowIndex, itemIndex, error}` を記録する（他のアイテム・ブロックの処理は継続する）。
+- `extractPages` は `errors` が空でなければ、それらを 1 件の `Error`（`ExtractPageResult.rewriteError`）へ集約して報告する — 既存の `rewriteError`（`rewritePageRefs` 由来）と同じフィールドを共有する。
 
 ### 設計上の注意
 

--- a/packages/@d-zero/site-migrator/README.md
+++ b/packages/@d-zero/site-migrator/README.md
@@ -179,6 +179,12 @@ anatomist の `LayoutBlock`/`RawLayoutNode` は要素の属性（`href` / `src` 
 
 `downloadBlockFiles` は `migrate()` が事前に収集した通常のリソース URL 集合（`knownResourceUrls`）と重複しない `download-file` アイテムの `path` だけを `downloadResources` へ追加投入する（fetch 処理そのものは再実装しない）。ダウンロード後（または既にカバー済みでスキップした場合も含めて）実ファイルサイズを `stat` で読み、`size`/`formatedSize` を実測値で書き戻す。同一ファイルが複数ページ・複数アイテムから参照されていてもダウンロードは 1 回で済ませる。
 
+### BurgerEditor ブロック内の同一オリジン参照書き換え（`rewriteBlockRefs`）
+
+`layoutToBlockData` が返す `BlockData[]` に含まれる同一オリジン URL（`wysiwyg` 内の `<a href>` 等、`button.link`、`image.path[]`、`download-file.path`）を、既存の `rewritePageRefs` と同じ正規化ルールで書き換える純関数（Issue #979）。`renderBlocks` を呼ぶ**前**、`BlockData` の段階で書き換える — レンダリング後の HTML 文字列に対して既存の `rewritePageRefs` をタグ名ベースで適用する方式だと、`button`/`download-file` アイテムはどちらも `<a href>` へレンダリングされ、両者を区別する `data-bgi` 属性が `<a>` 自身ではなく祖先要素に付与されるため、「button は page-ref 扱い（`{{<id>}}` 化あり）、download-file は asset 扱い（root-relative のみ）」を確実に区別できない。アイテム種別（`item.name`）が型として確定しているこの段階で書き換えることで、誤判定なく両者を区別する。`classifyBlockItem`/`layoutToBlockData`/`renderBlocks` 同様、統合前の内部 API のため `index.ts` からは export していない（`src/page-extractor/rewrite-block-refs.ts` を直接 import する）。統合先（`layoutToBlockData` → `rewriteBlockRefs` → `renderBlocks` の結線）は #976 で行う。
+
+- `rewriteBlockRefs(options: { blocks: BlockData[], baseUrl: string, pageIdLookup: PageIdLookup }): Promise<{ blocks: BlockData[], errors: RewriteBlockRefsError[] }>` — `wysiwyg` は `rewritePageRefs` へそのまま委譲、`button.link` はページ参照ルール（既知ページなら `{{<id>}}` 化）、`image.path[]`/`download-file.path` はアセットルール（root-relative のみ、`{{<id>}}` 化はしない）、`google-maps`/`youtube` の `url` は外部オリジンのため対象外。`wysiwyg` の `rewritePageRefs` 呼び出しが失敗した場合は fail-soft で元の内容を保持し、`errors` に `{blockIndex, rowIndex, itemIndex, error}` を記録する（他のアイテム・ブロックの処理は継続する）。
+
 ### 設計上の注意
 
 `extractMainContent` / `rewriteAssetRefs` / `mergeMainContent` は parse5 を内部で使う純関数、`getFrontmatter` は `@nitpicker/query` の DB 読み出しに依存する。両者の責務分離は `src/html/` (parse5) と `src/archive/` (`@nitpicker/query`) のディレクトリ構造で表現している。

--- a/packages/@d-zero/site-migrator/src/page-extractor/extract-pages.spec.ts
+++ b/packages/@d-zero/site-migrator/src/page-extractor/extract-pages.spec.ts
@@ -421,11 +421,15 @@ describe('extractPages', () => {
 		expect(written).not.toContain('href="/about/"');
 	});
 
-	test('fail-soft on rewritePageRefs throw: writes pre-rewrite HTML and surfaces rewriteError on the outcome', async () => {
+	test('fail-soft on rewriteBlockRefs (wysiwyg→rewritePageRefs) throw: writes pre-rewrite HTML and surfaces an aggregate rewriteError on the outcome', async () => {
 		getPageHtmlMock.mockResolvedValueOnce(
 			docWith('<main><a href="/about/">about</a></main>'),
 		);
 		mockConvertedLayout('<a href="/about/">about</a>');
+		// Converted pages no longer run the whole-body rewritePageRefs pass (it would
+		// double-process the already-rewritten block markup) — the single wysiwyg item
+		// produced from this layout is what invokes rewritePageRefs now, via
+		// rewriteBlockRefs.
 		rewritePageRefsMock.mockRejectedValueOnce(new Error('parse5 boom'));
 
 		const results: ExtractPageResult[] = [];
@@ -442,7 +446,10 @@ describe('extractPages', () => {
 		expect(results[0]).toMatchObject({
 			url: 'https://example.com/p',
 			outcome: 'extracted',
-			rewriteError: { message: 'parse5 boom' },
+			rewriteError: {
+				message:
+					'rewriteBlockRefs failed for 1 item(s): block 0/row 0/item 0: parse5 boom',
+			},
 		});
 		const written = await readFile(path.join(outputDir, 'p.html'), 'utf8');
 		// Body is the un-rewritten merged fragment (no {{id}} substitution).
@@ -510,6 +517,58 @@ describe('extractPages', () => {
 	});
 
 	describe('BurgerEditorブロック変換パイプライン', () => {
+		test('button: known-page link becomes {{id}} without double-rewrite corruption', async () => {
+			getPageHtmlMock.mockResolvedValueOnce(
+				docWith('<main><a class="btn" href="/about/">about</a></main>'),
+			);
+			mockConvertedLayout('<a class="btn" href="/about/">about</a>');
+
+			await extractPages({
+				session: FAKE_SESSION,
+				items: [
+					{ url: 'https://example.com/index.html' },
+					{ url: 'https://example.com/about/' },
+				],
+				outputDir,
+				contentClass: CONTENT_CLASS,
+				limit: 2,
+			});
+
+			const written = await readFile(path.join(outputDir, 'index.html'), 'utf8');
+			// `/index.html` is root section -> id 5, `/about/` is subdir section 1 -> id
+			// 10000 (see the wysiwyg-equivalent id-template test above).
+			expect(written).toContain('{{10000}}');
+			expect(written).not.toContain('href="/about/"');
+			// If rewriteBlockRefs' {{10000}} token got double-processed by the outer
+			// rewritePageRefs pass, it would corrupt into `%7B%7B10000%7D%7D`.
+			expect(written).not.toContain('%7B');
+		});
+
+		test('download-file: href pathname matching a known page id still stays root-relative (asset rule)', async () => {
+			getPageHtmlMock.mockResolvedValueOnce(
+				docWith('<main><a href="/files/report.pdf">Report</a></main>'),
+			);
+			mockConvertedLayout('<a href="/files/report.pdf">Report</a>');
+
+			await extractPages({
+				session: FAKE_SESSION,
+				items: [
+					{ url: 'https://example.com/index.html' },
+					// This URL's pathname exactly matches the download-file href above, to
+					// confirm the button/download-file distinction does not depend on
+					// pathname collisions with known pages.
+					{ url: 'https://example.com/files/report.pdf' },
+				],
+				outputDir,
+				contentClass: CONTENT_CLASS,
+				limit: 2,
+			});
+
+			const written = await readFile(path.join(outputDir, 'index.html'), 'utf8');
+			expect(written).toContain('href="/files/report.pdf"');
+			expect(written).not.toContain('{{');
+		});
+
 		test('resolvePageLayoutsを一括で1回だけ呼び、複数の一致ページをまとめて処理する', async () => {
 			getPageHtmlMock.mockResolvedValueOnce(docWith('<main><p>a</p></main>'));
 			getPageHtmlMock.mockResolvedValueOnce(docWith('<main><p>b</p></main>'));

--- a/packages/@d-zero/site-migrator/src/page-extractor/extract-pages.ts
+++ b/packages/@d-zero/site-migrator/src/page-extractor/extract-pages.ts
@@ -28,7 +28,12 @@ import {
 	resolvePageLayouts,
 	type ResolvePageLayoutResult,
 } from './resolve-page-layout.js';
-import { buildPageIdLookup, rewritePageRefs } from './rewrite-page-refs.js';
+import { rewriteBlockRefs, type RewriteBlockRefsError } from './rewrite-block-refs.js';
+import {
+	buildPageIdLookup,
+	rewritePageRefs,
+	type PageIdLookup,
+} from './rewrite-page-refs.js';
 
 /**
  * Single page to extract. Wrapped as an object so `@d-zero/dealer` (which
@@ -87,9 +92,11 @@ export type ExtractPageResult =
 			/** `blockConversion`が`fallback`のときのみセットされる致命的エラー。 */
 			blockConversionError?: Error;
 			/**
-			 * Present only when {@link rewritePageRefs} threw. The page body was
-			 * still written (fail-soft), but with original asset / page references
-			 * instead of the rewritten ones.
+			 * Present only when {@link rewritePageRefs} (unconverted/fallback pages)
+			 * or {@link rewriteBlockRefs} (converted/partial pages, one aggregate
+			 * `Error` per page even when multiple items failed) threw. The page
+			 * body was still written (fail-soft), but with original asset / page
+			 * references instead of the rewritten ones for the affected part.
 			 */
 			rewriteError?: Error;
 			/**
@@ -155,9 +162,17 @@ type BlockOutcome = FatalBlockOutcome | ResolvedBlockOutcome;
  * 渡す — ページごとに呼ぶとPuppeteerブラウザをページ数だけlaunch/closeすることになり
  * 実運用サイト規模では致命的に遅くなるため、ブラウザを1回だけ起動して使い回す。続けて
  * 各ページについて{@link layoutToBlockData}でBurgerEditorの`BlockData[]`へ変換し、
- * {@link renderBlocks}で`data-bge-*`付きHTMLへ変換し、{@link mergeMainContent}で
- * ラッパー要素を挟まずに既存main要素へ埋め込み、`rewritePageRefs`→frontmatter→
- * 書き出し、という既存の後段パイプラインへ合流させる。
+ * {@link rewriteBlockRefs}で`BlockData[]`内の同一オリジンURL（wysiwyg内の`<a href>`等、
+ * button.link、image.path[]、download-file.path）を書き換えてから{@link renderBlocks}で
+ * `data-bge-*`付きHTMLへ変換し、{@link mergeMainContent}でラッパー要素を挟まずに既存main
+ * 要素へ埋め込み、frontmatter→書き出し、という既存の後段パイプラインへ合流させる。
+ *
+ * ブロック変換したページの本文はこの時点で既に`rewriteBlockRefs`により書き換え済みのため、
+ * 後段の`rewritePageRefs`（本文全体への同一オリジン参照書き換え）は**適用しない** —
+ * 適用すると`rewriteBlockRefs`が既に埋め込んだ`{{<id>}}`トークンを`rewritePageRefs`が
+ * 通常URLとして再解釈し、`%7B%7B<id>%7D%7D`のようなpercent-encode文字列へ壊してしまう
+ * （ブロック変換が効かなかったページ・main非検出ページは元HTMLに`{{<id>}}`token が
+ * 存在しないため、従来通り`rewritePageRefs`を適用する）。
  *
  * ### ページ単位の致命的フォールバック
  *
@@ -188,7 +203,9 @@ type BlockOutcome = FatalBlockOutcome | ResolvedBlockOutcome;
  * - In both cases same-origin URLs are rewritten: `<a href>` / `<form action>`
  *   pointing at a known page → `{{<id>}}<query><fragment>`; other same-origin
  *   asset references → root-relative paths. Cross-origin URLs are left
- *   untouched. 生成したブロック内のURL自体の書き換えは対象外（#979の責務）。
+ *   untouched. ブロック変換したページ（`converted`/`partial`）は`rewriteBlockRefs`が
+ *   `button.link`をページ参照、`image.path[]`/`download-file.path`をアセット参照として
+ *   個別に扱う（詳細は{@link rewriteBlockRefs}のJSDoc参照）。
  *
  * Rewrite failure is fail-soft: the original HTML body is written and
  * `rewriteError` is set on the result so the caller can log a warning without
@@ -403,18 +420,32 @@ export async function extractPages(options: ExtractPagesOptions): Promise<void> 
 				}
 
 				const blockOutcome = blockOutcomeByUrl.get(entry.url)!;
-				const built = await buildExtractedBody(state, blockOutcome, contentClass);
+				const built = await buildExtractedBody(
+					state,
+					blockOutcome,
+					contentClass,
+					entry.url,
+					pageIdLookup,
+				);
 
 				let bodyHtml = built.body;
 				let rewriteError: Error | undefined;
-				try {
-					bodyHtml = await rewritePageRefs({
-						html: built.body,
-						baseUrl: entry.url,
-						pageIdLookup,
-					});
-				} catch (error) {
-					rewriteError = toError(error);
+				if (built.alreadyRewritten) {
+					// rewriteBlockRefsが既にbuilt.bodyを完全に書き換え済み。ここで
+					// rewritePageRefsをbody全体へ再適用すると、既に埋め込まれた`{{<id>}}`
+					// トークンが通常URLとして再解釈され文字化けするため、二重適用を避ける
+					// （buildExtractedBodyのJSDoc参照）。
+					rewriteError = aggregateBlockRewriteErrors(built.blockRewriteErrors);
+				} else {
+					try {
+						bodyHtml = await rewritePageRefs({
+							html: built.body,
+							baseUrl: entry.url,
+							pageIdLookup,
+						});
+					} catch (error) {
+						rewriteError = toError(error);
+					}
 				}
 
 				await writeFile(
@@ -502,46 +533,89 @@ function resolveBlockOutcome(
 }
 
 /**
- * `blockOutcome`から、rewritePageRefs適用前の本文HTMLと`blockConversion`分類を組み立てる。
+ * `blockOutcome`から本文HTMLと`blockConversion`分類を組み立てる。ブロック変換できた
+ * ページ（`converted`/`partial`）は`renderBlocks`を呼ぶ**前**に{@link rewriteBlockRefs}で
+ * `BlockData[]`内の同一オリジンURLを書き換えるため、返す`body`はこの時点で既に
+ * 書き換え済み（`alreadyRewritten: true`）— 呼び出し側は`rewritePageRefs`を`body`全体へ
+ * 重ねて適用してはならない（`{{<id>}}`トークンの二重処理による文字化けを防ぐため）。
  * `renderBlocks`/`mergeMainContent`が例外を投げた場合もここでfatalとして扱い、ページ全体の
- * 元の完全なHTMLへフォールバックする。
+ * 元の完全なHTMLへフォールバックする（この場合`alreadyRewritten: false`— 元の完全なHTMLは
+ * 未書き換えのため、呼び出し側の従来通りの`rewritePageRefs`適用が必要）。
  * @param state
  * @param state.originalHtml
  * @param state.extractedHtml
  * @param blockOutcome
  * @param contentClass
+ * @param baseUrl
+ * @param pageIdLookup
  */
 async function buildExtractedBody(
 	state: { readonly originalHtml: string; readonly extractedHtml: string },
 	blockOutcome: BlockOutcome,
 	contentClass: string,
+	baseUrl: string,
+	pageIdLookup: PageIdLookup,
 ): Promise<{
 	body: string;
 	blockConversion: 'converted' | 'partial' | 'fallback';
 	blockConversionError?: Error;
+	alreadyRewritten: boolean;
+	blockRewriteErrors?: readonly RewriteBlockRefsError[];
 }> {
 	if (blockOutcome.kind === 'fatal') {
 		return {
 			body: state.originalHtml,
 			blockConversion: 'fallback',
 			blockConversionError: blockOutcome.error,
+			alreadyRewritten: false,
 		};
 	}
 	try {
-		const wrapperHtml = await renderBlocks(blockOutcome.blocks, { contentClass });
+		const rewritten = await rewriteBlockRefs({
+			blocks: blockOutcome.blocks,
+			baseUrl,
+			pageIdLookup,
+		});
+		const wrapperHtml = await renderBlocks(rewritten.blocks, { contentClass });
 		const merged = mergeMainContent({
 			mainHtml: state.extractedHtml,
 			wrapperHtml,
 			contentClass,
 		});
-		return { body: merged, blockConversion: blockOutcome.kind };
+		return {
+			body: merged,
+			blockConversion: blockOutcome.kind,
+			alreadyRewritten: true,
+			...(rewritten.errors.length > 0 ? { blockRewriteErrors: rewritten.errors } : {}),
+		};
 	} catch (error) {
 		return {
 			body: state.originalHtml,
 			blockConversion: 'fallback',
 			blockConversionError: toError(error),
+			alreadyRewritten: false,
 		};
 	}
+}
+
+/**
+ * {@link rewriteBlockRefs}が返す複数の項目単位のエラーを、既存の`rewriteError?: Error`
+ * （1ページにつき1個）という`ExtractPageResult`の形へ合わせるため単一の`Error`へ集約する。
+ * @param errors
+ */
+function aggregateBlockRewriteErrors(
+	errors: readonly RewriteBlockRefsError[] | undefined,
+): Error | undefined {
+	if (!errors || errors.length === 0) {
+		return undefined;
+	}
+	const detail = errors
+		.map(
+			(e) =>
+				`block ${e.blockIndex}/row ${e.rowIndex}/item ${e.itemIndex}: ${e.error.message}`,
+		)
+		.join('; ');
+	return new Error(`rewriteBlockRefs failed for ${errors.length} item(s): ${detail}`);
 }
 
 /**

--- a/packages/@d-zero/site-migrator/src/page-extractor/rewrite-block-refs.spec.ts
+++ b/packages/@d-zero/site-migrator/src/page-extractor/rewrite-block-refs.spec.ts
@@ -1,0 +1,401 @@
+import type {
+	ButtonItemData,
+	DownloadFileItemData,
+	GoogleMapsItemData,
+	ImageEntryData,
+	TableItemData,
+	TitleH2Data,
+	TitleH3Data,
+	WysiwygItemData,
+	YoutubeItemData,
+} from './classify-block-item.js';
+import type { BlockData, BlockItem } from '@burger-editor/core';
+
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { rewriteBlockRefs } from './rewrite-block-refs.js';
+
+type RewritePageRefsModule = typeof import('./rewrite-page-refs.js');
+
+vi.mock('./rewrite-page-refs.js', async (importOriginal) => {
+	const actual = await importOriginal<RewritePageRefsModule>();
+	return {
+		...actual,
+		rewritePageRefs: vi.fn(actual.rewritePageRefs),
+	};
+});
+
+const { buildPageIdLookup, rewritePageRefs } = await import('./rewrite-page-refs.js');
+const rewritePageRefsMock = vi.mocked(rewritePageRefs);
+
+const BASE = 'https://example.com/about/';
+
+const lookupFrom = (entries: readonly (readonly [string, number])[]) =>
+	buildPageIdLookup(new Map(entries));
+
+/**
+ *
+ * @param items
+ */
+function block(items: BlockItem[][]): BlockData {
+	return { name: 'migrated', containerProps: { type: 'grid', columns: 1 }, items };
+}
+
+/**
+ *
+ * @param html
+ */
+function wysiwygItem(html: string): BlockItem {
+	return { name: 'wysiwyg', data: { wysiwyg: html } satisfies WysiwygItemData };
+}
+
+/**
+ *
+ * @param link
+ */
+function buttonItem(link: string): BlockItem {
+	return {
+		name: 'button',
+		data: {
+			link,
+			target: '',
+			text: '',
+			subtext: '',
+			kind: 'primary',
+			beforeIcon: 'none',
+			afterIcon: 'none',
+		} satisfies ButtonItemData,
+	};
+}
+
+/**
+ *
+ * @param path
+ */
+function imageItem(path: string[]): BlockItem {
+	return {
+		name: 'image',
+		data: {
+			path,
+			alt: path.map(() => ''),
+			width: path.map(() => 0),
+			height: path.map(() => 0),
+			media: path.map(() => ''),
+			loading: path.map(() => 'eager'),
+		} satisfies ImageEntryData,
+	};
+}
+
+/**
+ *
+ * @param path
+ */
+function downloadFileItem(path: string): BlockItem {
+	return {
+		name: 'download-file',
+		data: {
+			path,
+			download: '',
+			name: 'file',
+			formatedSize: '',
+			size: '',
+			downloadCheck: false,
+		} satisfies DownloadFileItemData,
+	};
+}
+
+/**
+ *
+ * @param url
+ */
+function googleMapsItem(url: string): BlockItem {
+	return {
+		name: 'google-maps',
+		data: { lat: 0, lng: 0, zoom: 16, url, img: '' } satisfies GoogleMapsItemData,
+	};
+}
+
+/**
+ *
+ * @param url
+ */
+function youtubeItem(url: string): BlockItem {
+	return {
+		name: 'youtube',
+		data: { id: '', title: '', thumb: '', url } satisfies YoutubeItemData,
+	};
+}
+
+/**
+ *
+ */
+function titleH2Item(): BlockItem {
+	return { name: 'title-h2', data: { titleH2: '見出し' } satisfies TitleH2Data };
+}
+
+/**
+ *
+ */
+function titleH3Item(): BlockItem {
+	return { name: 'title-h3', data: { titleH3: '見出し' } satisfies TitleH3Data };
+}
+
+/**
+ *
+ */
+function tableItem(): BlockItem {
+	return {
+		name: 'table',
+		data: { caption: '', th: [], td: [], scrollable: false } satisfies TableItemData,
+	};
+}
+
+/**
+ * @param item
+ */
+function dataOf<T>(item: BlockItem): T {
+	if (typeof item === 'string' || !item.data) {
+		throw new Error('unexpected bare-string or data-less BlockItem in test assertion');
+	}
+	return item.data as T;
+}
+
+describe('rewriteBlockRefs', () => {
+	beforeEach(async () => {
+		rewritePageRefsMock.mockReset();
+		const real = await vi.importActual<RewritePageRefsModule>('./rewrite-page-refs.js');
+		rewritePageRefsMock.mockImplementation(real.rewritePageRefs);
+	});
+
+	test('wysiwyg: 既知ページへの<a href>を{{id}}化する（rewritePageRefsへの委譲）', async () => {
+		const blocks = [block([[wysiwygItem('<a href="/news/">news</a>')]])];
+		const { blocks: result, errors } = await rewriteBlockRefs({
+			blocks,
+			baseUrl: BASE,
+			pageIdLookup: lookupFrom([['https://example.com/news/', 42]]),
+		});
+		expect(dataOf<WysiwygItemData>(result[0]!.items[0]![0]!).wysiwyg).toBe(
+			'<a href="{{42}}">news</a>',
+		);
+		expect(errors).toEqual([]);
+	});
+
+	test('wysiwyg: 同一オリジンの<img src>をroot-relative化する', async () => {
+		const blocks = [block([[wysiwygItem('<img src="../img/a.png">')]])];
+		const { blocks: result } = await rewriteBlockRefs({
+			blocks,
+			baseUrl: BASE,
+			pageIdLookup: lookupFrom([]),
+		});
+		expect(dataOf<WysiwygItemData>(result[0]!.items[0]![0]!).wysiwyg).toBe(
+			'<img src="/img/a.png">',
+		);
+	});
+
+	test('button: 既知ページへのlinkを{{id}}化する（query/fragment保持）', async () => {
+		const blocks = [block([[buttonItem('/news/?q=1#top')]])];
+		const { blocks: result } = await rewriteBlockRefs({
+			blocks,
+			baseUrl: BASE,
+			pageIdLookup: lookupFrom([['https://example.com/news/', 42]]),
+		});
+		expect(dataOf<ButtonItemData>(result[0]!.items[0]![0]!).link).toBe('{{42}}?q=1#top');
+	});
+
+	test('button: 同一オリジンだが未知ページのlinkはroot-relative化する', async () => {
+		const blocks = [block([[buttonItem('/unknown/')]])];
+		const { blocks: result } = await rewriteBlockRefs({
+			blocks,
+			baseUrl: BASE,
+			pageIdLookup: lookupFrom([]),
+		});
+		expect(dataOf<ButtonItemData>(result[0]!.items[0]![0]!).link).toBe('/unknown/');
+	});
+
+	test('button: クロスオリジンのlinkは無変更（参照同一性も維持）', async () => {
+		const original = buttonItem('https://other.example/x');
+		const blocks = [block([[original]])];
+		const { blocks: result } = await rewriteBlockRefs({
+			blocks,
+			baseUrl: BASE,
+			pageIdLookup: lookupFrom([]),
+		});
+		expect(dataOf<ButtonItemData>(result[0]!.items[0]![0]!).link).toBe(
+			'https://other.example/x',
+		);
+		expect(result[0]!.items[0]![0]).toBe(original);
+	});
+
+	test('image: pathnameが既知ページのidと一致していても{{id}}化しない（アセット扱い保証）', async () => {
+		const blocks = [block([[imageItem(['/news/'])]])];
+		const { blocks: result } = await rewriteBlockRefs({
+			blocks,
+			baseUrl: BASE,
+			pageIdLookup: lookupFrom([['https://example.com/news/', 42]]),
+		});
+		expect(dataOf<ImageEntryData>(result[0]!.items[0]![0]!).path).toEqual(['/news/']);
+	});
+
+	test('download-file: pathnameが既知ページのidと一致していても{{id}}化しない（アセット扱い保証・回帰防止の核）', async () => {
+		const blocks = [block([[downloadFileItem('/news/')]])];
+		const { blocks: result } = await rewriteBlockRefs({
+			blocks,
+			baseUrl: BASE,
+			pageIdLookup: lookupFrom([['https://example.com/news/', 42]]),
+		});
+		expect(dataOf<DownloadFileItemData>(result[0]!.items[0]![0]!).path).toBe('/news/');
+	});
+
+	test('google-maps/youtubeのurlフィールドは完全に無変更（対象外）', async () => {
+		const maps = googleMapsItem('https://maps.apple.com/?q=35,139');
+		const yt = youtubeItem('//www.youtube.com/embed/abc?rel=0');
+		const blocks = [block([[maps, yt]])];
+		const { blocks: result } = await rewriteBlockRefs({
+			blocks,
+			baseUrl: BASE,
+			pageIdLookup: lookupFrom([]),
+		});
+		expect(result[0]!.items[0]![0]).toBe(maps);
+		expect(result[0]!.items[0]![1]).toBe(yt);
+	});
+
+	test('title-h2/title-h3/table は参照同一性を維持したままパススルーする', async () => {
+		const h2 = titleH2Item();
+		const h3 = titleH3Item();
+		const table = tableItem();
+		const blocks = [block([[h2, h3, table]])];
+		const { blocks: result } = await rewriteBlockRefs({
+			blocks,
+			baseUrl: BASE,
+			pageIdLookup: lookupFrom([]),
+		});
+		expect(result[0]!.items[0]![0]).toBe(h2);
+		expect(result[0]!.items[0]![1]).toBe(h3);
+		expect(result[0]!.items[0]![2]).toBe(table);
+	});
+
+	test('bare-stringのBlockItemはそのまま通す', async () => {
+		const blocks = [block([['plain-item-name' as unknown as BlockItem]])];
+		const { blocks: result } = await rewriteBlockRefs({
+			blocks,
+			baseUrl: BASE,
+			pageIdLookup: lookupFrom([]),
+		});
+		expect(result[0]!.items[0]![0]).toBe('plain-item-name');
+	});
+
+	test('dataを持たないBlockItem（name のみ）はそのまま通す', async () => {
+		const original: BlockItem = { name: 'button' };
+		const blocks = [block([[original]])];
+		const { blocks: result } = await rewriteBlockRefs({
+			blocks,
+			baseUrl: BASE,
+			pageIdLookup: lookupFrom([]),
+		});
+		expect(result[0]!.items[0]![0]).toBe(original);
+	});
+
+	test('button: mailto:等の対象外スキームは無変更（参照同一性も維持）', async () => {
+		const original = buttonItem('mailto:info@example.com');
+		const blocks = [block([[original]])];
+		const { blocks: result } = await rewriteBlockRefs({
+			blocks,
+			baseUrl: BASE,
+			pageIdLookup: lookupFrom([['https://example.com/news/', 42]]),
+		});
+		expect(dataOf<ButtonItemData>(result[0]!.items[0]![0]!).link).toBe(
+			'mailto:info@example.com',
+		);
+		expect(result[0]!.items[0]![0]).toBe(original);
+	});
+
+	test('button: 空文字・bare-fragmentのlinkは無変更', async () => {
+		const blocks = [block([[buttonItem(''), buttonItem('#top')]])];
+		const { blocks: result } = await rewriteBlockRefs({
+			blocks,
+			baseUrl: BASE,
+			pageIdLookup: lookupFrom([]),
+		});
+		expect(dataOf<ButtonItemData>(result[0]!.items[0]![0]!).link).toBe('');
+		expect(dataOf<ButtonItemData>(result[0]!.items[0]![1]!).link).toBe('#top');
+	});
+
+	test('image: 全pathがクロスオリジン等で無変更の場合はitem参照をそのまま維持する（button/download-fileとの不変条件統一）', async () => {
+		const original = imageItem(['https://other.example/a.png']);
+		const blocks = [block([[original]])];
+		const { blocks: result } = await rewriteBlockRefs({
+			blocks,
+			baseUrl: BASE,
+			pageIdLookup: lookupFrom([]),
+		});
+		expect(result[0]!.items[0]![0]).toBe(original);
+	});
+
+	test('image: 複数pathのうち同一オリジン/クロスオリジンが混在しても個別に解決する', async () => {
+		const blocks = [block([[imageItem(['/img/a.png', 'https://other.example/b.png'])]])];
+		const { blocks: result } = await rewriteBlockRefs({
+			blocks,
+			baseUrl: BASE,
+			pageIdLookup: lookupFrom([]),
+		});
+		expect(dataOf<ImageEntryData>(result[0]!.items[0]![0]!).path).toEqual([
+			'/img/a.png',
+			'https://other.example/b.png',
+		]);
+	});
+
+	test('入力blocksを変更しない（純粋関数）', async () => {
+		const original = block([[buttonItem('/news/')]]);
+		const blocks = [original];
+		const snapshot = structuredClone(blocks);
+
+		await rewriteBlockRefs({
+			blocks,
+			baseUrl: BASE,
+			pageIdLookup: lookupFrom([['https://example.com/news/', 42]]),
+		});
+
+		expect(blocks).toEqual(snapshot);
+	});
+
+	test('不正なbaseUrlの場合は無変更・例外なしで返す', async () => {
+		const blocks = [block([[buttonItem('/news/')]])];
+		const { blocks: result, errors } = await rewriteBlockRefs({
+			blocks,
+			baseUrl: 'not a url',
+			pageIdLookup: lookupFrom([]),
+		});
+		expect(result).toEqual(blocks);
+		expect(errors).toEqual([]);
+	});
+
+	test('fail-soft: wysiwygのrewritePageRefs失敗時は元の内容を保持しerrorsに記録し、他アイテムは処理を継続する', async () => {
+		const okItem = buttonItem('/news/');
+		const failingWysiwyg = '<a href="/broken/">broken</a>';
+		const blocks = [
+			block([[wysiwygItem(failingWysiwyg), okItem]]),
+			block([[wysiwygItem('<a href="/news/">ok</a>')]]),
+		];
+
+		rewritePageRefsMock.mockImplementationOnce(() => {
+			throw new Error('boom');
+		});
+
+		const { blocks: result, errors } = await rewriteBlockRefs({
+			blocks,
+			baseUrl: BASE,
+			pageIdLookup: lookupFrom([['https://example.com/news/', 42]]),
+		});
+
+		expect(dataOf<WysiwygItemData>(result[0]!.items[0]![0]!).wysiwyg).toBe(
+			failingWysiwyg,
+		);
+		expect(errors).toEqual([
+			{ blockIndex: 0, rowIndex: 0, itemIndex: 0, error: new Error('boom') },
+		]);
+		expect(dataOf<ButtonItemData>(result[0]!.items[0]![1]!).link).toBe('{{42}}');
+		expect(dataOf<WysiwygItemData>(result[1]!.items[0]![0]!).wysiwyg).toBe(
+			'<a href="{{42}}">ok</a>',
+		);
+	});
+});

--- a/packages/@d-zero/site-migrator/src/page-extractor/rewrite-block-refs.ts
+++ b/packages/@d-zero/site-migrator/src/page-extractor/rewrite-block-refs.ts
@@ -1,0 +1,266 @@
+import type {
+	ButtonItemData,
+	DownloadFileItemData,
+	ImageEntryData,
+	WysiwygItemData,
+} from './classify-block-item.js';
+import type { PageIdLookup } from './rewrite-page-refs.js';
+import type { BlockData, BlockItem } from '@burger-editor/core';
+
+import { rewritePageRefs } from './rewrite-page-refs.js';
+
+export interface RewriteBlockRefsOptions {
+	/** `layoutToBlockData`が生成した`BlockData[]`（`renderBlocks`へ渡す前のもの）。 */
+	readonly blocks: readonly BlockData[];
+	/** このブロック群が属するページのURL。相対URL解決の基点として使う。 */
+	readonly baseUrl: string;
+	/**
+	 * `buildPageIdLookup`で構築済みのルックアップテーブル。マイグレーション実行全体で
+	 * 使い回す想定（`rewritePageRefs`と同じ制約 — 呼び出しごとの再構築はO(N²)）。
+	 */
+	readonly pageIdLookup: PageIdLookup;
+}
+
+export interface RewriteBlockRefsError {
+	readonly blockIndex: number;
+	readonly rowIndex: number;
+	readonly itemIndex: number;
+	/** `rewritePageRefs`が投げた例外（`wysiwyg`アイテムのみが発生源）。 */
+	readonly error: Error;
+}
+
+export interface RewriteBlockRefsResult {
+	readonly blocks: BlockData[];
+	/**
+	 * `wysiwyg`アイテムの`rewritePageRefs`呼び出しが失敗した箇所の記録（fail-soft —
+	 * `extract-pages.ts`の`rewriteError`と同方針）。該当アイテムは元の内容のまま返され、
+	 * 他のアイテム・ブロックの処理は継続する。
+	 */
+	readonly errors: RewriteBlockRefsError[];
+}
+
+/**
+ * `<a>`/`<form>`等のページ参照タグが対象かを問わず、値がURL属性そのもの（ページ参照タグの
+ * 属性値相当）として扱われる場合に限り除外するスキーム集合。`rewrite-page-refs.ts`の
+ * `SKIPPED_SCHEMES`と同一の値だが、そちら側を変更せず本ファイル単体で完結させるため
+ * （#979の非スコープ: `rewritePageRefs`自体のロジック変更）意図的に複製している。
+ */
+const SKIPPED_SCHEMES: ReadonlySet<string> = new Set([
+	'mailto:',
+	'tel:',
+	'sms:',
+	'javascript:',
+	'data:',
+	'blob:',
+	'vbscript:',
+	'file:',
+]);
+
+interface RewriteContext {
+	readonly baseUrl: string;
+	readonly basePageOrigin: string;
+	readonly pageIdLookup: PageIdLookup;
+	readonly blockIndex: number;
+	readonly rowIndex: number;
+	readonly itemIndex: number;
+	readonly errors: RewriteBlockRefsError[];
+}
+
+/**
+ * BurgerEditorブロック（`BlockData[]`）内の同一オリジンURLフィールドを、既存の
+ * `rewritePageRefs`と同じ正規化ルールで書き換える。`renderBlocks`（`@burger-editor/core`の
+ * `render()`）を呼ぶ**前**に適用する — レンダリング後のHTML文字列に対して既存の
+ * `rewritePageRefs`をタグ名ベースで適用する方式では、`button`アイテムと`download-file`
+ * アイテムがどちらも`<a href>`へレンダリングされ、両者を区別する`data-bgi`属性は`<a>`
+ * 自身ではなく祖先要素に付与されるため、「buttonはpage-ref扱い（`{{id}}`化あり）、
+ * download-fileはasset扱い（root-relativeのみ）」という要件を確実に満たせない
+ * （祖先追跡ロジックの新規実装が必要になり`rewritePageRefs`の複雑化を招く）。アイテム種別
+ * （`item.name`）が型として確定しているこの段階でフィールドを直接書き換えることで、
+ * 誤判定リスクなく両者を区別する。
+ *
+ * アイテム種別ごとの扱い（Issue #979の要件）:
+ * - `wysiwyg`: `data.wysiwyg`（HTML文字列）に既存の`rewritePageRefs`をそのまま適用する。
+ * - `button`: `data.link`をページ参照として扱う（既知ページなら`{{<id>}}`化、それ以外は
+ *   root-relative化）。
+ * - `image`: `data.path[]`の各要素をアセット参照として扱う（root-relativeのみ、
+ *   `{{<id>}}`化は行わない）。
+ * - `download-file`: `data.path`をアセット参照として扱う（`image`と同様）。
+ * - `google-maps`/`youtube`の`url`、`title-h2`/`title-h3`/`table`: 対象外・無変更。
+ * @param options
+ * @example
+ * ```ts
+ * const { blocks, errors } = await rewriteBlockRefs({
+ *   blocks: layoutToBlockData(results).blocks,
+ *   baseUrl: 'https://example.com/about/',
+ *   pageIdLookup: buildPageIdLookup(pageIds),
+ * });
+ * const html = await renderBlocks(blocks, { contentClass: 'js-bge-content' });
+ * ```
+ */
+export async function rewriteBlockRefs(
+	options: RewriteBlockRefsOptions,
+): Promise<RewriteBlockRefsResult> {
+	const { blocks, baseUrl, pageIdLookup } = options;
+
+	let basePageOrigin: string;
+	try {
+		basePageOrigin = new URL(baseUrl).origin;
+	} catch {
+		return { blocks: [...blocks], errors: [] };
+	}
+
+	const errors: RewriteBlockRefsError[] = [];
+	const nextBlocks: BlockData[] = [];
+
+	for (const [blockIndex, block] of blocks.entries()) {
+		const nextItems: BlockItem[][] = [];
+		for (const [rowIndex, row] of block.items.entries()) {
+			const nextRow: BlockItem[] = [];
+			for (const [itemIndex, item] of row.entries()) {
+				const ctx: RewriteContext = {
+					baseUrl,
+					basePageOrigin,
+					pageIdLookup,
+					blockIndex,
+					rowIndex,
+					itemIndex,
+					errors,
+				};
+				nextRow.push(await rewriteBlockItem(item, ctx));
+			}
+			nextItems.push(nextRow);
+		}
+		nextBlocks.push({ ...block, items: nextItems });
+	}
+
+	return { blocks: nextBlocks, errors };
+}
+
+/**
+ * @param item
+ * @param ctx
+ */
+async function rewriteBlockItem(
+	item: BlockItem,
+	ctx: RewriteContext,
+): Promise<BlockItem> {
+	if (typeof item === 'string' || !item.data) {
+		// `BlockItem`は`string`（アイテム名のみ）や`data`省略も許容する緩い型
+		// （`@burger-editor/core`）のため、書き換え対象フィールドが存在しない場合はそのまま
+		// 通す。
+		return item;
+	}
+
+	switch (item.name) {
+		case 'button': {
+			const data = item.data as ButtonItemData;
+			const link = resolveSameOriginUrl(data.link, ctx, true);
+			return link === null ? item : { ...item, data: { ...data, link } };
+		}
+		case 'image': {
+			const data = item.data as ImageEntryData;
+			const resolvedPath = data.path.map((p) => resolveSameOriginUrl(p, ctx, false));
+			if (resolvedPath.every((p) => p === null)) {
+				// button/download-fileと同様、全要素が無変更（クロスオリジン等でnull）なら
+				// 元のitem参照をそのまま返す — 呼び出し側が参照同一性で変更有無を判定できる
+				// ようにするための不変条件。
+				return item;
+			}
+			const path = resolvedPath.map((p, i) => p ?? data.path[i]!);
+			return { ...item, data: { ...data, path } };
+		}
+		case 'download-file': {
+			const data = item.data as DownloadFileItemData;
+			const path = resolveSameOriginUrl(data.path, ctx, false);
+			return path === null ? item : { ...item, data: { ...data, path } };
+		}
+		case 'wysiwyg': {
+			return await rewriteWysiwygItem(
+				item as { name: 'wysiwyg'; data: WysiwygItemData },
+				ctx,
+			);
+		}
+		default: {
+			// google-maps/youtubeのurl（外部オリジン埋め込み用）、title-h2/title-h3/table
+			// （URLフィールドなし）は対象外。
+			return item;
+		}
+	}
+}
+
+/**
+ * `wysiwyg`アイテムの`data.wysiwyg`（HTML文字列）に既存の`rewritePageRefs`を適用する。
+ * 失敗時は元の内容を保持し`ctx.errors`へ記録する fail-soft 方針
+ * （`extract-pages.ts`の`rewriteError`と同じ）。
+ * @param item
+ * @param item.name
+ * @param item.data
+ * @param ctx
+ */
+async function rewriteWysiwygItem(
+	item: { name: 'wysiwyg'; data: WysiwygItemData },
+	ctx: RewriteContext,
+): Promise<BlockItem> {
+	try {
+		const wysiwyg = await rewritePageRefs({
+			html: item.data.wysiwyg,
+			baseUrl: ctx.baseUrl,
+			pageIdLookup: ctx.pageIdLookup,
+		});
+		return { ...item, data: { wysiwyg } };
+	} catch (error) {
+		ctx.errors.push({
+			blockIndex: ctx.blockIndex,
+			rowIndex: ctx.rowIndex,
+			itemIndex: ctx.itemIndex,
+			error: error instanceof Error ? error : new Error(String(error)),
+		});
+		return item;
+	}
+}
+
+/**
+ * `BlockData`のフィールドから取り出した生URL文字列1個を、`rewritePageRefs`の既存resolverと
+ * 同じセマンティクス（trim、bare-fragment/空文字は無視、非対応スキームとクロスオリジンは
+ * 無変更、query/fragment保持）で解決する。`treatAsPageRef`が`true`かつ既知ページに一致する
+ * 場合のみ`{{<id>}}`化する — `false`を渡す`image`/`download-file`は同じpathnameが既知ページと
+ * 一致していても常にroot-relativeのままになる（この関数の存在意義そのもの）。
+ * @param rawUrl
+ * @param ctx
+ * @param treatAsPageRef
+ * @returns 書き換え後の値。無変更とすべき場合（空/bare-fragment/スキーム対象外/
+ *   クロスオリジン/パース不能）は`null`。
+ */
+function resolveSameOriginUrl(
+	rawUrl: string,
+	ctx: RewriteContext,
+	treatAsPageRef: boolean,
+): string | null {
+	const trimmed = rawUrl.trim();
+	if (trimmed === '' || trimmed.startsWith('#')) {
+		return null;
+	}
+	let resolved: URL;
+	try {
+		resolved = new URL(trimmed, ctx.baseUrl);
+	} catch {
+		return null;
+	}
+	if (SKIPPED_SCHEMES.has(resolved.protocol)) {
+		return null;
+	}
+	if (resolved.origin !== ctx.basePageOrigin) {
+		return null;
+	}
+	if (treatAsPageRef) {
+		const exact = ctx.pageIdLookup.byExact.get(
+			`${resolved.origin}${resolved.pathname}${resolved.search}`,
+		);
+		const id =
+			exact ?? ctx.pageIdLookup.byPathname.get(`${resolved.origin}${resolved.pathname}`);
+		if (id !== undefined) {
+			return `{{${id}}}${resolved.search}${resolved.hash}`;
+		}
+	}
+	return `${resolved.pathname}${resolved.search}${resolved.hash}`;
+}


### PR DESCRIPTION
## Summary

- Add `rewriteBlockRefs` (`src/page-extractor/rewrite-block-refs.ts`), applied to a page's `BlockData[]` before `renderBlocks`: `wysiwyg` content delegates to the existing `rewritePageRefs`, `button.link` is treated as a page reference (`{{<id>}}` for known pages), `image.path[]`/`download-file.path` are treated as asset references (root-relative only, never `{{<id>}}`), and `google-maps`/`youtube` `url` fields are left untouched (external origin).
- Rewriting happens at the `BlockData` level rather than on `renderBlocks`' HTML output because `button` and `download-file` items both render as `<a href>`, and the `data-bgi` attribute that distinguishes them sits on an ancestor element, not the anchor itself — a post-render, tag-name-based rewrite can't reliably tell a page-ref button link from an asset-only download-file link.
- Wire `rewriteBlockRefs` into `extractPages` (`src/page-extractor/extract-pages.ts`), which already runs the whole-page `rewritePageRefs` pass added by the just-merged BurgerEditor block-conversion integration. For pages with successful block conversion, skip that whole-body pass afterward — running it again over `rewriteBlockRefs`' output would reinterpret an already-rewritten `{{<id>}}` token as a literal URL path segment and corrupt it into a percent-encoded string (verified: `{{42}}` → `/%7B%7B42%7D%7D`). Fallback pages (no block conversion) are unaffected and keep the previous whole-document `rewritePageRefs` pass.
- `rewriteBlockRefs`' per-item errors are aggregated into a single `Error` to fit the existing single `rewriteError`-per-page field on `ExtractPageResult`.
- Update `README.md` to document `rewriteBlockRefs` and the revised per-page pipeline order.

Refs #979.

## Test plan

- [x] `packages/@d-zero/site-migrator/src/page-extractor/rewrite-block-refs.spec.ts` (new, 18 cases): button/image/download-file/wysiwyg rules, the asset-rule guarantee for `image`/`download-file` even when a path's pathname coincides with a known page id, fail-soft on `rewritePageRefs` failure, immutability, invalid `baseUrl`.
- [x] `extract-pages.spec.ts`: updated the existing fail-soft test for the new aggregated-error shape; added two full-pipeline regression tests — a button link to a known page becomes `{{<id>}}` without double-rewrite corruption, and a download-file href whose pathname matches a known page id still stays root-relative.
- [x] `yarn vitest run packages/@d-zero/site-migrator` — 22 files, 265 tests pass.
- [x] `yarn test` (repo-wide) — 23 files, 275 tests pass.
- [x] `yarn build` — type-checks clean.
- [x] `yarn lint` — eslint/prettier/textlint/cspell all pass.
