### PR TITLE
feat(site-migrator): verify rendered blocks round-trip through parseHTMLToBlockData

### DIFF
--- a/packages/@d-zero/site-migrator/README.md
+++ b/packages/@d-zero/site-migrator/README.md
@@ -138,16 +138,16 @@ import {
 
 処理は次の要素で構成される（いずれも `src/page-extractor/` 配下、統合前は内部 API だったが `extractPages` に組み込まれた現在も `index.ts` からは export していない）:
 
-| 関数                 | 概要                                                                                                                                                                            |
-| -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `resolvePageLayouts` | `--layout-json` の事前生成 JSONL を優先し、無ければ Puppeteer + `@d-zero/anatomist` でライブ解析する                                                                            |
-| `classifyBlockItem`  | anatomist の `LayoutBlock` 1 個を `image`/`title-h2`/`title-h3`/`youtube`/`google-maps`/`download-file`/`button`/`table`/`wysiwyg` へヒューリスティック分類する純関数           |
-| `layoutToBlockData`  | 複数ビューポート分の解析結果から `BlockData[]` を組み立てる純関数。ブロック単位の低信頼度は個別に `wysiwyg` へ倒し `fallbacks` に記録する                                       |
-| `rewriteBlockRefs`   | `BlockData[]` 内の同一オリジン URL を `renderBlocks` 前に書き換える（詳細は後述の専用節）                                                                                       |
-| `renderBlocks`       | `@burger-editor/core` の公式 `render()` で `BlockData[]` を `data-bge-*` 付き HTML へ変換する                                                                                   |
-| `mergeMainContent`   | `renderBlocks` のラッパー `<div>` の中身だけを既存 main 要素の子要素として差し替え、`--content-class` を main 要素自身の `classList` に追加する（新規ラッパー要素は追加しない） |
-| `isMainConsistent`   | anatomist の `mainSelector` と `extractMainContent` がマッチした要素の `outerHTML` を比較する簡易整合性チェック                                                                 |
-| `downloadBlockFiles` | 生成ブロック内の `download-file` アイテムの `path` を集めて `downloadResources` へ二重 DL を避けつつ追加投入し、実ファイルサイズを `size`/`formatedSize` に反映する             |
+| 関数                 | 概要                                                                                                                                                                                                                                                                     |
+| -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `resolvePageLayouts` | `--layout-json` の事前生成 JSONL を優先し、無ければ Puppeteer + `@d-zero/anatomist` でライブ解析する                                                                                                                                                                     |
+| `classifyBlockItem`  | anatomist の `LayoutBlock` 1 個を `image`/`title-h2`/`title-h3`/`youtube`/`google-maps`/`download-file`/`button`/`table`/`wysiwyg` へヒューリスティック分類する純関数                                                                                                    |
+| `layoutToBlockData`  | 複数ビューポート分の解析結果から `BlockData[]` を組み立てる純関数。ブロック単位の低信頼度は個別に `wysiwyg` へ倒し `fallbacks` に記録する                                                                                                                                |
+| `rewriteBlockRefs`   | `BlockData[]` 内の同一オリジン URL を `renderBlocks` 前に書き換える（詳細は後述の専用節）                                                                                                                                                                                |
+| `renderBlocks`       | `@burger-editor/core` の公式 `render()` で `BlockData[]` を `data-bge-*` 付き HTML へ変換する。ブロックごとに `render()` 直後に `parseHTMLToBlockData` で逆パースし変換元と構造的に一致するか往復検証し、不一致なら `wysiwyg` 単一アイテムへ倒す（詳細は次のセクション） |
+| `mergeMainContent`   | `renderBlocks` のラッパー `<div>` の中身だけを既存 main 要素の子要素として差し替え、`--content-class` を main 要素自身の `classList` に追加する（新規ラッパー要素は追加しない）                                                                                          |
+| `isMainConsistent`   | anatomist の `mainSelector` と `extractMainContent` がマッチした要素の `outerHTML` を比較する簡易整合性チェック                                                                                                                                                          |
+| `downloadBlockFiles` | 生成ブロック内の `download-file` アイテムの `path` を集めて `downloadResources` へ二重 DL を避けつつ追加投入し、実ファイルサイズを `size`/`formatedSize` に反映する                                                                                                      |
 
 `extractPages` はページごとに以下の順で処理する:
 
@@ -158,6 +158,7 @@ import {
 #### ブロック単位フォールバックとページ単位フォールバックの区別
 
 - **ブロック単位**（致命的ではない）: `layoutToBlockData` が低信頼度・ビューポート不一致・`rowSizes` 不正形状と判断した個別ブロックだけを `wysiwyg` 単一アイテムに倒す。閾値は設けない。他の高信頼度ブロックはそのまま出力し、ページ全体は諦めない。この場合 `ExtractPageResult.blockConversion` は `'partial'` になる。
+- **往復検証によるブロック単位フォールバック**（致命的ではない、Issue #980）: `layoutToBlockData` が高信頼度と判断したブロックでも、`renderBlocks` が `render()` 直後に `parseHTMLToBlockData` で逆パースし直し、`name`/`containerProps.type`/`items` の行数・列数・各アイテムの `name` が変換元と一致するかを確認する。不一致（`render()`/`parseHTMLToBlockData` 側の未知のバグ等）を検出したブロックのみ、`render()` が実際に生成した HTML をそのまま `wysiwyg` 単一アイテムとして包み直す（他ブロックには影響しない）。往復検証の不一致は `renderBlocks` の `onRoundTripMismatch` コールバック（開発時デバッグ用途、既定では未使用）でのみ観測でき、現時点では `ExtractPageResult.blockConversion`／`onResult` には反映されない（パイプライン統合・レポートへの組み込みは Issue #976 の範囲）。
 - **ページ単位**（致命的）: 以下のいずれかに該当する場合のみ、そのページ全体を `data-bge-*` マーカー無しのプレーンな元の完全な HTML として出力する（`blockConversion: 'fallback'`、原因は `blockConversionError`）。**品質判断（低信頼度ブロックが多い等）によるページ全体フォールバックは行わない**:
   - `resolvePageLayouts` がそのページについて完全に失敗した（ライブ URL 到達不可等）
   - `isMainConsistent` が anatomist の `mainSelector` と `extractMainContent` のマッチ不一致と判定した（簡易判定。厳密な整合化は将来の課題）

--- a/packages/@d-zero/site-migrator/src/page-extractor/build-wysiwyg-fallback-block.spec.ts
+++ b/packages/@d-zero/site-migrator/src/page-extractor/build-wysiwyg-fallback-block.spec.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from 'vitest';
+
+import { buildWysiwygFallbackBlock } from './build-wysiwyg-fallback-block.js';
+
+describe('buildWysiwygFallbackBlock', () => {
+	test('1行1列のwysiwyg単一アイテムを持つBlockDataを組み立てる', () => {
+		const block = buildWysiwygFallbackBlock('<p>hello</p>', { name: 'migrated' });
+
+		expect(block).toEqual({
+			name: 'migrated',
+			containerProps: { type: 'grid', columns: 1 },
+			items: [[{ name: 'wysiwyg', data: { wysiwyg: '<p>hello</p>' } }]],
+		});
+	});
+
+	test('classList/style/idを指定した場合はBlockDataに含める', () => {
+		const block = buildWysiwygFallbackBlock('<p>hello</p>', {
+			name: 'migrated',
+			classList: ['js-highlight'],
+			style: { '--gap': '8px' },
+			id: 'anchor-1',
+		});
+
+		expect(block.classList).toEqual(['js-highlight']);
+		expect(block.style).toEqual({ '--gap': '8px' });
+		expect(block.id).toBe('anchor-1');
+	});
+
+	test('classList/style/idを省略した場合はBlockDataに含めない', () => {
+		const block = buildWysiwygFallbackBlock('<p>hello</p>', { name: 'migrated' });
+
+		expect(block).not.toHaveProperty('classList');
+		expect(block).not.toHaveProperty('style');
+		expect(block).not.toHaveProperty('id');
+	});
+
+	test('idがnullの場合はBlockDataにid:nullとして含める（省略しない）', () => {
+		const block = buildWysiwygFallbackBlock('<p>hello</p>', {
+			name: 'migrated',
+			id: null,
+		});
+
+		expect(block).toHaveProperty('id', null);
+	});
+});

--- a/packages/@d-zero/site-migrator/src/page-extractor/build-wysiwyg-fallback-block.ts
+++ b/packages/@d-zero/site-migrator/src/page-extractor/build-wysiwyg-fallback-block.ts
@@ -1,0 +1,37 @@
+import type { BlockData } from '@burger-editor/core';
+
+export interface WysiwygFallbackBlockOptions {
+	/** フォールバックブロックの`name`。呼び出し元の文脈に応じて決める（固定値/元ブロック引継ぎ等）。 */
+	readonly name: string;
+	readonly classList?: readonly string[];
+	readonly style?: Record<string, string>;
+	readonly id?: string | null;
+}
+
+/**
+ * 構造化できなかった（または往復検証に失敗した）ブロックを、1行1列の`wysiwyg`単一アイテムへ
+ * 倒す。`layout-to-block-data.ts`の低信頼度フォールバックと`render-blocks.ts`の往復検証
+ * フォールバック（#980）の両方が使う共通の形 — どちらも判定基準・呼び出し元は異なるが、
+ * 「構造化を諦めて生HTMLをそのままwysiwygとして保持する」という最終形は同一。
+ * @param rawHtml `wysiwyg`アイテムの`data.wysiwyg`として保持する生HTML。
+ * @param options
+ * @example
+ * ```ts
+ * const block = buildWysiwygFallbackBlock('<p>hello</p>', { name: 'migrated' });
+ * // { name: 'migrated', containerProps: { type: 'grid', columns: 1 },
+ * //   items: [[{ name: 'wysiwyg', data: { wysiwyg: '<p>hello</p>' } }]] }
+ * ```
+ */
+export function buildWysiwygFallbackBlock(
+	rawHtml: string,
+	options: WysiwygFallbackBlockOptions,
+): BlockData {
+	return {
+		name: options.name,
+		containerProps: { type: 'grid', columns: 1 },
+		items: [[{ name: 'wysiwyg', data: { wysiwyg: rawHtml } }]],
+		...(options.classList ? { classList: options.classList } : {}),
+		...(options.style ? { style: options.style } : {}),
+		...(options.id === undefined ? {} : { id: options.id }),
+	};
+}

--- a/packages/@d-zero/site-migrator/src/page-extractor/layout-to-block-data.ts
+++ b/packages/@d-zero/site-migrator/src/page-extractor/layout-to-block-data.ts
@@ -1,6 +1,7 @@
 import type { BlockData, BlockItem, ContainerProps } from '@burger-editor/core';
 import type { LayoutAnalysisResult, LayoutBlock } from '@d-zero/anatomist/types';
 
+import { buildWysiwygFallbackBlock } from './build-wysiwyg-fallback-block.js';
 import { classifyBlockItem, wysiwygItem } from './classify-block-item.js';
 
 export type BlockFallbackReason =
@@ -285,11 +286,9 @@ function readFloatDirection(signals: Record<string, unknown>): 'start' | 'end' |
  * @param node
  */
 function wysiwygBlockData(node: LayoutBlock): BlockData {
-	return {
+	return buildWysiwygFallbackBlock(wysiwygItem(node).data.wysiwyg, {
 		name: MIGRATED_BLOCK_NAME,
-		containerProps: { type: 'grid', columns: 1 },
-		items: [[toBlockItem(wysiwygItem(node))]],
-	};
+	});
 }
 
 /**

--- a/packages/@d-zero/site-migrator/src/page-extractor/render-blocks.spec.ts
+++ b/packages/@d-zero/site-migrator/src/page-extractor/render-blocks.spec.ts
@@ -1,8 +1,22 @@
 import type { BlockData } from '@burger-editor/core';
 
-import { describe, expect, test } from 'vitest';
+import { parseHTMLToBlockData, render } from '@burger-editor/core';
+import { describe, expect, test, vi } from 'vitest';
 
 import { renderBlocks } from './render-blocks.js';
+
+// `render-blocks.ts`が呼ぶ`render`と（`verifyBlockRoundTrip`経由の）`parseHTMLToBlockData`を
+// スパイでラップする。既定では実装（`actual`）へそのまま転送するため、ここで
+// `mockReturnValueOnce`/`mockImplementationOnce`しない限り既存テストの挙動は一切変わらない —
+// 往復検証のフォールバック分岐（#980）だけを狙って検証するための仕込み。
+vi.mock('@burger-editor/core', async (importOriginal) => {
+	const actual = await importOriginal<typeof import('@burger-editor/core')>();
+	return {
+		...actual,
+		render: vi.fn(actual.render),
+		parseHTMLToBlockData: vi.fn(actual.parseHTMLToBlockData),
+	};
+});
 
 /**
  * @param overrides
@@ -86,5 +100,107 @@ describe('renderBlocks', () => {
 		const html = await renderBlocks([], { contentClass: '"><script>' });
 
 		expect(html).toBe('<div class="&quot;><script>"></div>');
+	});
+
+	test('往復検証が一致する場合はonRoundTripMismatchを呼ばない', async () => {
+		const onRoundTripMismatch = vi.fn();
+
+		await renderBlocks([sampleBlock()], { contentClass: 'wrap', onRoundTripMismatch });
+
+		expect(onRoundTripMismatch).not.toHaveBeenCalled();
+	});
+
+	test('往復検証の不一致を検出したブロックはwysiwygフォールバックへ倒し、onRoundTripMismatchを呼ぶ', async () => {
+		vi.mocked(parseHTMLToBlockData).mockReturnValueOnce({
+			name: 'not-matching',
+			containerProps: { type: 'inline' },
+			items: [[{ name: 'wysiwyg', data: { wysiwyg: 'x' } }]],
+		});
+		const block = sampleBlock();
+		const onRoundTripMismatch = vi.fn();
+
+		const html = await renderBlocks([block], {
+			contentClass: 'wrap',
+			onRoundTripMismatch,
+		});
+
+		expect(onRoundTripMismatch).toHaveBeenCalledTimes(1);
+		const event = onRoundTripMismatch.mock.calls[0]![0];
+		expect(event.blockIndex).toBe(0);
+		expect(event.block).toBe(block);
+		expect(event.mismatches.length).toBeGreaterThan(0);
+
+		// フォールバック後のトップレベルブロックはフォールバック自身の1個だけ
+		// （data-bge-name="migrated"は1回だけ出現する）— 失敗した元ブロックの
+		// render()出力はwysiwygアイテムの内容としてネストされ、wysiwygのサニタイズにより
+		// 構造マーカー（data-bge-name/data-bge-group/data-bge-item）は失われるが、
+		// 見た目上のコンテンツ（`<p>hello</p>`）は保持される。
+		const nameAttrCount = [...html.matchAll(/data-bge-name="migrated"/g)].length;
+		expect(nameAttrCount).toBe(1);
+		expect(html).toContain('<p>hello</p>');
+	});
+
+	test('往復検証に失敗したブロックが複数中の1個でも、他ブロックは通常どおり変換される', async () => {
+		vi.mocked(parseHTMLToBlockData).mockReturnValueOnce({
+			name: 'not-matching',
+			containerProps: { type: 'inline' },
+			items: [[{ name: 'wysiwyg', data: { wysiwyg: 'x' } }]],
+		});
+
+		const html = await renderBlocks(
+			[
+				sampleBlock({
+					name: 'first',
+					items: [[{ name: 'wysiwyg', data: { wysiwyg: 'A' } }]],
+				}),
+				sampleBlock({
+					name: 'second',
+					items: [[{ name: 'wysiwyg', data: { wysiwyg: 'B' } }]],
+				}),
+			],
+			{ contentClass: 'wrap' },
+		);
+
+		expect(html).toContain('data-bge-name="second"');
+		expect(html).toContain('B');
+	});
+
+	test('フォールバック時もclassList/style/idを引き継ぐ', async () => {
+		vi.mocked(parseHTMLToBlockData).mockReturnValueOnce({
+			name: 'not-matching',
+			containerProps: { type: 'inline' },
+			items: [[{ name: 'wysiwyg', data: { wysiwyg: 'x' } }]],
+		});
+		const block = sampleBlock({
+			classList: ['js-highlight'],
+			style: { '--gap': '8px' },
+			id: 'anchor-1',
+		});
+
+		const html = await renderBlocks([block], { contentClass: 'wrap' });
+
+		expect(html).toContain('js-highlight');
+		expect(html).toContain('bge-anchor-1');
+	});
+
+	test('フォールバック用のrender()自体が失敗しても例外を伝播させず、往復検証に失敗した元のelementをそのまま使う', async () => {
+		vi.mocked(parseHTMLToBlockData).mockReturnValueOnce({
+			name: 'not-matching',
+			containerProps: { type: 'inline' },
+			items: [[{ name: 'wysiwyg', data: { wysiwyg: 'x' } }]],
+		});
+		const defaultImpl = vi.mocked(render).getMockImplementation()!;
+		vi.mocked(render)
+			.mockImplementationOnce(defaultImpl) // 1回目（通常のブロック描画）は実装通り
+			.mockImplementationOnce(() => {
+				throw new Error('fallback render failed');
+			}); // 2回目（フォールバックの再render）は失敗させる
+
+		const html = await renderBlocks([sampleBlock()], { contentClass: 'wrap' });
+
+		// フォールバックが失敗しても例外は投げられず、往復検証に失敗した（が一応レンダリング
+		// はできている）元のブロックのHTMLがそのまま出力される。
+		expect(html).toContain('data-bge-name="migrated"');
+		expect(html).toContain('<p>hello</p>');
 	});
 });

--- a/packages/@d-zero/site-migrator/src/page-extractor/render-blocks.ts
+++ b/packages/@d-zero/site-migrator/src/page-extractor/render-blocks.ts
@@ -1,8 +1,12 @@
+import type { RoundTripMismatch } from './verify-block-round-trip.js';
 import type { BlockData } from '@burger-editor/core';
 
 import { items } from '@burger-editor/blocks';
 import { render } from '@burger-editor/core';
 import { JSDOM } from 'jsdom';
+
+import { buildWysiwygFallbackBlock } from './build-wysiwyg-fallback-block.js';
+import { verifyBlockRoundTrip } from './verify-block-round-trip.js';
 
 export interface RenderBlocksOptions {
 	/**
@@ -10,6 +14,20 @@ export interface RenderBlocksOptions {
 	 * （BurgerEditorの`editableArea`セレクタに対応させるためのもの）。
 	 */
 	contentClass: string;
+	/**
+	 * ブロックの往復検証（{@link verifyBlockRoundTrip}）が不一致を検出した際に呼ばれる。
+	 * 開発時のデバッグ用途向けの通知であり、省略しても`renderBlocks`の変換動作
+	 * （そのブロックをwysiwygフォールバックへ倒す挙動）自体は変わらない。
+	 */
+	onRoundTripMismatch?: (event: BlockRoundTripMismatchEvent) => void;
+}
+
+export interface BlockRoundTripMismatchEvent {
+	/** `blocks`配列内でのインデックス。 */
+	readonly blockIndex: number;
+	/** 往復検証に失敗した変換元の`BlockData`。 */
+	readonly block: BlockData;
+	readonly mismatches: readonly RoundTripMismatch[];
 }
 
 let domInstalled = false;
@@ -59,6 +77,14 @@ function ensureDomEnvironment(): void {
  * `data-bge-*`付きのHTML要素を生成し、それらを連結した上で`options.contentClass`を持つ
  * ラッパー要素で囲む。アイテムカタログはカスタマイズ不可で、常に`@burger-editor/blocks`の
  * 既定カタログ（`items`）を使う。
+ *
+ * 各ブロックは`render()`直後に{@link verifyBlockRoundTrip}で往復検証する（#980）—
+ * 同じ`@burger-editor/core`の`parseHTMLToBlockData`で生成HTMLを逆パースし、変換元の
+ * `BlockData`と構造的に一致するかを確認する。不一致（`render()`/`parseHTMLToBlockData`
+ * 側の未知のバグ等）を検出した場合、そのブロックのみ#974の低信頼度フォールバックと同じ
+ * 扱い（1行1列のwysiwygアイテムとして生HTMLを保持）に倒す — `render()`が実際に生成した
+ * `outerHTML`をそのままwysiwygの内容として包み直し、`data-bge-*`マーカー付きの
+ * フォールバックブロックとして再度`render()`する。他ブロックの見た目・変換結果には影響しない。
  * @param blocks
  * @param options
  * @example
@@ -74,14 +100,57 @@ export async function renderBlocks(
 	ensureDomEnvironment();
 
 	const htmlParts: string[] = [];
-	for (const block of blocks) {
+	for (const [blockIndex, block] of blocks.entries()) {
 		// render()はページ内のブロック順を保つため直列に実行する（並列化しても速度上の利点が
 		// 薄く、生成順の見た目上の意味を崩すリスクを避ける）。
-		const element = await render(block, { items });
+		let element = await render(block, { items });
+
+		const verification = verifyBlockRoundTrip(block, element);
+		if (!verification.ok) {
+			options.onRoundTripMismatch?.({
+				blockIndex,
+				block,
+				mismatches: verification.mismatches,
+			});
+			try {
+				element = await render(buildRoundTripFallback(block, element.outerHTML), {
+					items,
+				});
+			} catch {
+				// フォールバック用の再render()自体が失敗した場合、往復検証に失敗した
+				// （が一応レンダリングはできている）元のelementをそのまま使う。ここで例外を
+				// 伝播させると、このブロック1個の問題で呼び出し元（extract-pages.ts）が
+				// ページ全体をfatalへ落とし他の正常ブロックまで失う — このJSDocが約束する
+				// 「他ブロックの見た目・変換結果には影響しない」を保つための最終手段。
+			}
+		}
+
 		htmlParts.push(element.outerHTML);
 	}
 
 	return `<div class="${escapeAttribute(options.contentClass)}">${htmlParts.join('')}</div>`;
+}
+
+/**
+ * 往復検証（{@link verifyBlockRoundTrip}）に失敗したブロックを、#974の低信頼度フォールバック
+ * と同じ形（{@link buildWysiwygFallbackBlock}）へ倒す。`rawHtml`には検証対象だった`render()`
+ * の出力（`element.outerHTML`）をそのまま渡す — その中に元ブロック自身の`data-bge-*`属性が
+ * ネストして残るが、`@burger-editor/core`の`listBlocks`は`editableArea`直下の子要素
+ * （`:scope > [data-bge-container]`）のみをブロックとして走査するため、ネストした属性が
+ * 上位のブロック走査へ影響することはない。
+ * `name`に加えて`classList`/`style`/`id`も引き継ぐ — 往復検証はこれらのプロパティを比較対象に
+ * しない（`verifyBlockRoundTrip`のJSDoc参照）ため、フォールバックへ倒す理由（`items`の構造
+ * 不一致等）とは無関係に保持でき、CSSフックやアンカーリンク（`id`）を壊さない。
+ * @param block 往復検証に失敗した変換元の`BlockData`。
+ * @param rawHtml フォールバック後もそのまま保持する生HTML。
+ */
+function buildRoundTripFallback(block: BlockData, rawHtml: string): BlockData {
+	return buildWysiwygFallbackBlock(rawHtml, {
+		name: block.name,
+		classList: block.classList,
+		style: block.style,
+		id: block.id,
+	});
 }
 
 /**

--- a/packages/@d-zero/site-migrator/src/page-extractor/verify-block-round-trip.spec.ts
+++ b/packages/@d-zero/site-migrator/src/page-extractor/verify-block-round-trip.spec.ts
@@ -1,0 +1,181 @@
+import type { BlockData } from '@burger-editor/core';
+
+import { JSDOM } from 'jsdom';
+import { describe, expect, test } from 'vitest';
+
+import { renderBlocks } from './render-blocks.js';
+import { verifyBlockRoundTrip } from './verify-block-round-trip.js';
+
+/**
+ * `renderBlocks`（実際の`@burger-editor/core`の`render()`）でblockを描画し、
+ * `verifyBlockRoundTrip`が受け取る`HTMLElement`（描画結果1ブロック分）を、`renderBlocks`の
+ * DOM環境インストールと無関係な独立した`JSDOM`インスタンスで再構築して返す。
+ * @param block 描画対象の`BlockData`。
+ */
+async function renderToElement(block: BlockData): Promise<HTMLElement> {
+	const html = await renderBlocks([block], { contentClass: 'wrap' });
+	const dom = new JSDOM(html);
+	const element = dom.window.document.querySelector('[data-bge-name]');
+	if (!element) {
+		throw new Error('renderBlocks output did not contain a data-bge-name element');
+	}
+	return element as unknown as HTMLElement;
+}
+
+/**
+ * @param overrides
+ */
+function sampleBlock(overrides: Partial<BlockData> = {}): BlockData {
+	return {
+		name: 'migrated',
+		containerProps: { type: 'grid', columns: 2 },
+		items: [
+			[
+				{ name: 'wysiwyg', data: { wysiwyg: 'A' } },
+				{ name: 'wysiwyg', data: { wysiwyg: 'B' } },
+			],
+			[
+				{ name: 'wysiwyg', data: { wysiwyg: 'C' } },
+				{ name: 'wysiwyg', data: { wysiwyg: 'D' } },
+			],
+		],
+		...overrides,
+	};
+}
+
+describe('verifyBlockRoundTrip', () => {
+	test('render結果が変換元と構造的に一致する場合はok:true・mismatches:[]', async () => {
+		const block = sampleBlock();
+		const element = await renderToElement(block);
+
+		const result = verifyBlockRoundTrip(block, element);
+
+		expect(result).toEqual({ ok: true, mismatches: [] });
+	});
+
+	test('classList/style/idの差異は比較対象外のためok:trueのまま', async () => {
+		const base = sampleBlock();
+		const rendered = await renderToElement(base);
+		const original = sampleBlock({
+			classList: ['js-highlight'],
+			style: { '--gap': '8px' },
+			id: 'anchor-1',
+		});
+
+		const result = verifyBlockRoundTrip(original, rendered);
+
+		expect(result).toEqual({ ok: true, mismatches: [] });
+	});
+
+	test('nameの不一致を検出する', async () => {
+		const rendered = await renderToElement(sampleBlock());
+		const original = sampleBlock({ name: 'other' });
+
+		const result = verifyBlockRoundTrip(original, rendered);
+
+		expect(result.ok).toBe(false);
+		expect(result.mismatches).toContainEqual({
+			field: 'name',
+			expected: 'other',
+			actual: 'migrated',
+		});
+	});
+
+	test('containerProps.typeの不一致を検出する', async () => {
+		const rendered = await renderToElement(sampleBlock());
+		const original = sampleBlock({ containerProps: { type: 'inline' } });
+
+		const result = verifyBlockRoundTrip(original, rendered);
+
+		expect(result.ok).toBe(false);
+		expect(result.mismatches).toContainEqual({
+			field: 'containerProps.type',
+			expected: 'inline',
+			actual: 'grid',
+		});
+	});
+
+	test('itemsの行数不一致を検出し、行単位の比較は行わない', async () => {
+		const base = sampleBlock();
+		const rendered = await renderToElement(base);
+		const original = sampleBlock({ items: [base.items[0]!] });
+
+		const result = verifyBlockRoundTrip(original, rendered);
+
+		expect(result.ok).toBe(false);
+		expect(result.mismatches).toEqual([
+			{ field: 'items.length', expected: 1, actual: 2 },
+		]);
+	});
+
+	test('itemsの列数不一致を検出する', async () => {
+		const base = sampleBlock();
+		const rendered = await renderToElement(base);
+		const original = sampleBlock({
+			items: [[base.items[0]![0]!], base.items[1]!],
+		});
+
+		const result = verifyBlockRoundTrip(original, rendered);
+
+		expect(result.ok).toBe(false);
+		expect(result.mismatches).toContainEqual({
+			field: 'items[0].length',
+			expected: 1,
+			actual: 2,
+		});
+	});
+
+	test('itemsの各セルのname不一致を行×列の位置ベースで検出する', async () => {
+		const base = sampleBlock();
+		const rendered = await renderToElement(base);
+		const original = sampleBlock({
+			items: [
+				[{ name: 'button', data: { link: [''], label: [''] } }, base.items[0]![1]!],
+				base.items[1]!,
+			],
+		});
+
+		const result = verifyBlockRoundTrip(original, rendered);
+
+		expect(result.ok).toBe(false);
+		expect(result.mismatches).toContainEqual({
+			field: 'items[0][0].name',
+			expected: 'button',
+			actual: 'wysiwyg',
+		});
+	});
+
+	test('複数箇所の不一致をすべて返す（最初の不一致で短絡しない）', async () => {
+		const rendered = await renderToElement(sampleBlock());
+		const original = sampleBlock({ name: 'other', containerProps: { type: 'inline' } });
+
+		const result = verifyBlockRoundTrip(original, rendered);
+
+		expect(result.mismatches).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({ field: 'name' }),
+				expect.objectContaining({ field: 'containerProps.type' }),
+			]),
+		);
+		expect(result.mismatches).toHaveLength(2);
+	});
+
+	test('parseHTMLToBlockDataが例外を投げた場合はok:falseとして扱う', () => {
+		const throwingElement = {
+			get dataset(): never {
+				throw new Error('boom');
+			},
+		} as unknown as HTMLElement;
+
+		const result = verifyBlockRoundTrip(sampleBlock(), throwingElement);
+
+		expect(result.ok).toBe(false);
+		expect(result.mismatches).toEqual([
+			{
+				field: 'parseHTMLToBlockData',
+				expected: '例外を投げないこと',
+				actual: 'boom',
+			},
+		]);
+	});
+});

--- a/packages/@d-zero/site-migrator/src/page-extractor/verify-block-round-trip.ts
+++ b/packages/@d-zero/site-migrator/src/page-extractor/verify-block-round-trip.ts
@@ -1,0 +1,130 @@
+import type { BlockData, BlockItem } from '@burger-editor/core';
+
+import { parseHTMLToBlockData } from '@burger-editor/core';
+
+export interface RoundTripMismatch {
+	/** 不一致箇所を指すパス（例: `'name'`、`'containerProps.type'`、`'items[0][1].name'`）。 */
+	readonly field: string;
+	readonly expected: unknown;
+	readonly actual: unknown;
+}
+
+export interface RoundTripVerification {
+	readonly ok: boolean;
+	/** `ok`が`true`のときは常に空配列。 */
+	readonly mismatches: readonly RoundTripMismatch[];
+}
+
+/**
+ * `@burger-editor/core`の`render()`が生成した`rendered`（1ブロック分のHTMLElement）を、同じ
+ * `@burger-editor/core`の`parseHTMLToBlockData`で逆パースし直し、変換元の`original`と構造的に
+ * 一致するかを検証する。深い内容比較（`data`フィールドの値そのもの等）は行わず、
+ * BurgerEditor側の`listBlocks`/`getBlockAtPosition`等が構造化ブロックとして正しく認識できるかの
+ * 指標となる範囲（`name`、`containerProps.type`、`items`の行数・各行の列数、各アイテムの`name`）
+ * のみを比較する。
+ * `parseHTMLToBlockData`自体が例外を投げた場合も不一致として扱う（安全側 — 呼び出し元が
+ * 例外で落ちないようにする）。
+ * @param original `renderBlocks`が`render()`に渡した変換元の`BlockData`。
+ * @param rendered `render(original, options)`が返した`HTMLElement`。
+ * @example
+ * ```ts
+ * const rendered = await render(block, { items });
+ * const verification = verifyBlockRoundTrip(block, rendered);
+ * if (!verification.ok) {
+ *   console.warn(verification.mismatches);
+ * }
+ * ```
+ */
+export function verifyBlockRoundTrip(
+	original: BlockData,
+	rendered: HTMLElement,
+): RoundTripVerification {
+	let parsed: BlockData;
+	try {
+		parsed = parseHTMLToBlockData(rendered);
+	} catch (error) {
+		return {
+			ok: false,
+			mismatches: [
+				{
+					field: 'parseHTMLToBlockData',
+					expected: '例外を投げないこと',
+					actual: error instanceof Error ? error.message : String(error),
+				},
+			],
+		};
+	}
+
+	const mismatches: RoundTripMismatch[] = [];
+
+	if (parsed.name !== original.name) {
+		mismatches.push({ field: 'name', expected: original.name, actual: parsed.name });
+	}
+	if (parsed.containerProps.type !== original.containerProps.type) {
+		mismatches.push({
+			field: 'containerProps.type',
+			expected: original.containerProps.type,
+			actual: parsed.containerProps.type,
+		});
+	}
+
+	compareItems(original.items, parsed.items, mismatches);
+
+	return { ok: mismatches.length === 0, mismatches };
+}
+
+/**
+ * `original`/`parsed`両方の`items`（行×列のBlockItem構造）を、行数→各行の列数→各セルの
+ * `name`の順に位置ベースで比較し、不一致を`mismatches`へ追記する。行数・列数が既に不一致な
+ * 行は、対応するセルが存在しない/意味を持たないため`name`比較をスキップする。
+ * @param original 変換元の`items`。
+ * @param parsed 逆パースで得た`items`。
+ * @param mismatches 検出した不一致を追記する配列（呼び出し元と共有、破壊的に変更する）。
+ */
+function compareItems(
+	original: BlockData['items'],
+	parsed: BlockData['items'],
+	mismatches: RoundTripMismatch[],
+): void {
+	if (parsed.length !== original.length) {
+		mismatches.push({
+			field: 'items.length',
+			expected: original.length,
+			actual: parsed.length,
+		});
+		return;
+	}
+
+	for (const [rowIndex, originalRow] of original.entries()) {
+		const parsedRow = parsed[rowIndex]!;
+		if (parsedRow.length !== originalRow.length) {
+			mismatches.push({
+				field: `items[${rowIndex}].length`,
+				expected: originalRow.length,
+				actual: parsedRow.length,
+			});
+			continue;
+		}
+
+		for (const [itemIndex, originalItem] of originalRow.entries()) {
+			const parsedItem = parsedRow[itemIndex]!;
+			const expected = itemName(originalItem);
+			const actual = itemName(parsedItem);
+			if (expected !== actual) {
+				mismatches.push({
+					field: `items[${rowIndex}][${itemIndex}].name`,
+					expected,
+					actual,
+				});
+			}
+		}
+	}
+}
+
+/**
+ * `BlockItem`（文字列 or `{name, data}`オブジェクト）から比較対象の`name`を取り出す。
+ * @param item 比較対象の`BlockItem`。
+ */
+function itemName(item: BlockItem): string {
+	return typeof item === 'string' ? item : item.name;
+}


### PR DESCRIPTION
## Summary

- Add `verifyBlockRoundTrip`: right after `renderBlocks()` renders a block via `@burger-editor/core`'s `render()`, re-parse the resulting `HTMLElement` with the same package's `parseHTMLToBlockData` and compare it structurally against the source `BlockData` (`name`, `containerProps.type`, `items` row/column shape, each item's `name`).
- On a mismatch, demote that single block to the same low-confidence wysiwyg-only shape `layout-to-block-data.ts` already uses (`buildWysiwygFallbackBlock`, newly extracted as a shared helper), wrapping the block's own rendered `outerHTML` so the visual output is preserved. Other blocks on the page are unaffected, and if the fallback's own re-`render()` throws, `renderBlocks` keeps the original (unverified) element rather than losing the whole page.
- Add an optional `onRoundTripMismatch` callback on `RenderBlocksOptions` for development-time visibility into detected mismatches (wiring it into `extractPages`'s report is left to #976, per #980's stated non-scope).
- Update the site-migrator README's block-conversion pipeline section to document this new fallback path.

Closes #980.

## Test plan

- [x] `yarn test` — 293 tests pass, including new coverage for: exact match, each mismatch kind (name / containerProps.type / items row count / items column count / item name), multiple simultaneous mismatches, `parseHTMLToBlockData` throwing, `classList`/`style`/`id` being ignored by comparison but preserved through the fallback, and the fallback's own `render()` failing without losing the page.
- [x] `yarn lint` — 0 errors (pre-existing warnings in untouched files only).
- [x] `yarn build` — succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
