### PR TITLE
feat(site-migrator): classify collapsed a/img/iframe blocks via anatomist attributes

### DIFF
--- a/packages/@d-zero/site-migrator/README.md
+++ b/packages/@d-zero/site-migrator/README.md
@@ -167,7 +167,7 @@ import {
 
 #### 既知の制限（重要）
 
-anatomist の `LayoutBlock`/`RawLayoutNode` は要素の属性（`href` / `src` / `srcset` / `alt` / `width` / `height` 等）を保持しない（保持されるのは `tagName`/`id`/`classList`/`boundingBox`/`style`/`innerHTML`/`children` のみ）。加えて `should-recurse.ts` の collapse ロジックにより `<picture><source><img></picture>` のようなラッパー構造は最終的に `img` 自身（void 要素、`innerHTML` は空）だけが残る。そのため **実データでは `image` / `youtube` / `google-maps` / `download-file` / `button.link` の判定条件（src/href）がほぼ常に取得できず、safe に `wysiwyg` へフォールバックする**。これはバグではなく、属性情報が存在しないデータに対する意図された安全側の挙動であり、コード自体は正しいロジックを実装している（anatomist が将来属性を捕捉するようになれば自動的に機能する）。anatomist 側の属性キャプチャ拡張は別途フォローアップ課題として扱う。
+`should-recurse.ts` の collapse ロジックにより `<picture><source><img></picture>` のようなラッパー構造は最終的に `img` 自身（void 要素、`innerHTML` は空）だけが残ることがある。anatomist 0.3.0 以降、`LayoutBlock.attributes`（`href`/`src`/`srcset`/`action`/`alt`/`target`/`download` の固定 allowlist、生値のまま）経由でこのケースの `href`/`src` を取得できるため、`classifyBlockItem` はブロック自身のタグが `<a>`/`<img>`/`<iframe>` になったケースでも `button`/`download-file`/`image`/`youtube`/`google-maps` へ分類できる（`d-zero-dev/tools` Issue #941）。ただし `width`/`height`/`loading`/iframe の `title` 属性は allowlist 外のため未取得のままで、`image` アイテムは `width`/`height` を `0`、`loading` を `'eager'` 固定でフォールバックする。また `<a href><picture>…</picture></a>` のようにラッパー側（子ではなく祖先）が属性を持つケースは、collapse で祖先自体が消えるため引き続き救済されない（祖先の属性を保持する仕組みが別途必要で、フォローアップ課題として扱う）。
 
 その他の設計上のポイント:
 

--- a/packages/@d-zero/site-migrator/package.json
+++ b/packages/@d-zero/site-migrator/package.json
@@ -34,7 +34,7 @@
 	"dependencies": {
 		"@burger-editor/blocks": "4.0.0-alpha.70",
 		"@burger-editor/core": "4.0.0-alpha.70",
-		"@d-zero/anatomist": "0.2.0",
+		"@d-zero/anatomist": "0.3.0",
 		"@d-zero/dealer": "1.10.1",
 		"@d-zero/shared": "0.22.2",
 		"@nitpicker/crawler": "0.11.0",

--- a/packages/@d-zero/site-migrator/src/page-extractor/classify-block-item.spec.ts
+++ b/packages/@d-zero/site-migrator/src/page-extractor/classify-block-item.spec.ts
@@ -15,6 +15,7 @@ function sampleBlock(overrides: Partial<LayoutBlock> = {}): LayoutBlock {
 		classList: [],
 		boundingBox: { x: 0, y: 0, width: 100, height: 100 },
 		innerHTML: '',
+		attributes: {},
 		confidence: 0,
 		signals: {},
 		children: [],
@@ -211,12 +212,63 @@ describe('classifyBlockItem', () => {
 		expect(result.name).toBe('wysiwyg');
 	});
 
-	test('collapseによりimg自身がブロックになった場合（innerHTMLが空、属性取得不能）はwysiwygにフォールバックする', () => {
+	test('collapseによりimg自身がブロックになった場合、attributesが無ければwysiwygにフォールバックする', () => {
 		// 実データで高頻度に起きるケース: anatomistのcollapseロジックによりpicture/figure等の
 		// ラッパー情報が失われ、img自身（void要素、innerHTMLは空）だけがLayoutBlockとして残る。
-		const block = sampleBlock({ tagName: 'IMG', innerHTML: '' });
+		// anatomist 0.2.x等、attributesを持たないデータではsrcを取得できずwysiwygのまま。
+		const block = sampleBlock({ tagName: 'IMG', innerHTML: '', attributes: undefined });
 		const result = classifyBlockItem(block);
 		expect(result.name).toBe('wysiwyg');
+	});
+
+	test('collapseによりimg自身がブロックになった場合でも、attributesにsrcがあればimageになる', () => {
+		const block = sampleBlock({
+			tagName: 'IMG',
+			innerHTML: '',
+			attributes: { src: '/photo.png', alt: '写真' },
+		});
+		const result = classifyBlockItem(block);
+		expect(result).toStrictEqual({
+			name: 'image',
+			data: {
+				path: ['/photo.png'],
+				alt: ['写真'],
+				width: [0],
+				height: [0],
+				media: [''],
+				loading: ['eager'],
+			},
+		});
+	});
+
+	test('img自身がブロックになった場合、attributesにsrcが無ければwysiwygにフォールバックする', () => {
+		const block = sampleBlock({
+			tagName: 'IMG',
+			innerHTML: '',
+			attributes: { alt: '写真のみ' },
+		});
+		const result = classifyBlockItem(block);
+		expect(result.name).toBe('wysiwyg');
+	});
+
+	test('img自身がブロックになった場合、attributesにaltが無ければ空文字になる', () => {
+		const block = sampleBlock({
+			tagName: 'IMG',
+			innerHTML: '',
+			attributes: { src: '/x.jpg' },
+		});
+		const result = classifyBlockItem(block);
+		expect(result).toStrictEqual({
+			name: 'image',
+			data: {
+				path: ['/x.jpg'],
+				alt: [''],
+				width: [0],
+				height: [0],
+				media: [''],
+				loading: ['eager'],
+			},
+		});
 	});
 
 	test('iframe（youtube）はidを抽出し、thumb/urlをBurgerEditor正規形で生成する', () => {
@@ -317,6 +369,53 @@ describe('classifyBlockItem', () => {
 		expect(result.name).toBe('wysiwyg');
 	});
 
+	test('collapseによりiframe自身がブロックになった場合でも、attributesのsrcからyoutubeを分類できる', () => {
+		const block = sampleBlock({
+			tagName: 'IFRAME',
+			innerHTML: '',
+			attributes: { src: 'https://www.youtube.com/embed/ZZZZ' },
+		});
+		const result = classifyBlockItem(block);
+		expect(result).toStrictEqual({
+			name: 'youtube',
+			data: {
+				id: 'ZZZZ',
+				title: 'YouTube動画',
+				thumb: '//img.youtube.com/vi/ZZZZ/maxresdefault.jpg',
+				url: '//www.youtube.com/embed/ZZZZ?rel=0&loop=1&autoplay=1&autohide=1&start=0',
+			},
+		});
+	});
+
+	test('collapseによりiframe自身がブロックになった場合でも、attributesのsrcからgoogle-mapsを分類できる', () => {
+		const block = sampleBlock({
+			tagName: 'IFRAME',
+			innerHTML: '',
+			attributes: { src: 'https://www.google.com/maps?q=35.1,139.1' },
+		});
+		const result = classifyBlockItem(block);
+		expect(result).toStrictEqual({
+			name: 'google-maps',
+			data: {
+				lat: 35.1,
+				lng: 139.1,
+				zoom: 16,
+				url: '//maps.apple.com/?q=35.1,139.1',
+				img: '',
+			},
+		});
+	});
+
+	test('iframe自身がブロックになった場合、attributesにsrcが無ければwysiwygにフォールバックする', () => {
+		const block = sampleBlock({
+			tagName: 'IFRAME',
+			innerHTML: '',
+			attributes: undefined,
+		});
+		const result = classifyBlockItem(block);
+		expect(result.name).toBe('wysiwyg');
+	});
+
 	test('既知拡張子かつボタン風クラスを持つaはdownload-fileが勝つ（button優先順位テスト）', () => {
 		const block = sampleBlock({
 			tagName: 'DIV',
@@ -394,11 +493,12 @@ describe('classifyBlockItem', () => {
 		expect(result.name).toBe('button');
 	});
 
-	test('ブロック自身がaの場合、collapseによりhrefが取得できずbuttonに倒れる', () => {
+	test('ブロック自身がaの場合、attributesが無ければhrefが取得できずlinkが空のままbuttonに倒れる', () => {
 		const block = sampleBlock({
 			tagName: 'A',
 			classList: ['c-btn'],
 			innerHTML: 'お問い合わせ',
+			attributes: undefined,
 		});
 		const result = classifyBlockItem(block);
 		expect(result).toStrictEqual({
@@ -413,6 +513,58 @@ describe('classifyBlockItem', () => {
 				afterIcon: 'none',
 			},
 		});
+	});
+
+	test('ブロック自身がaの場合、attributesのhrefからlinkを取得してbuttonになる', () => {
+		const block = sampleBlock({
+			tagName: 'A',
+			classList: ['c-btn'],
+			innerHTML: 'お問い合わせ',
+			attributes: { href: '/contact' },
+		});
+		const result = classifyBlockItem(block);
+		expect(result).toStrictEqual({
+			name: 'button',
+			data: {
+				link: '/contact',
+				target: '',
+				text: 'お問い合わせ',
+				subtext: '',
+				kind: 'primary',
+				beforeIcon: 'none',
+				afterIcon: 'none',
+			},
+		});
+	});
+
+	test('ブロック自身がaの場合、attributesのhrefが既知拡張子ならdownload-fileになる', () => {
+		const block = sampleBlock({
+			tagName: 'A',
+			innerHTML: '資料',
+			attributes: { href: '/docs/file.pdf' },
+		});
+		const result = classifyBlockItem(block);
+		expect(result).toStrictEqual({
+			name: 'download-file',
+			data: {
+				path: '/docs/file.pdf',
+				download: '',
+				name: 'file.pdf',
+				formatedSize: '',
+				size: '',
+				downloadCheck: false,
+			},
+		});
+	});
+
+	test('ブロック自身がaの場合、attributesにhrefがあってもボタン風クラスが無ければwysiwygになる', () => {
+		const block = sampleBlock({
+			tagName: 'A',
+			innerHTML: '会社概要',
+			attributes: { href: '/about' },
+		});
+		const result = classifyBlockItem(block);
+		expect(result.name).toBe('wysiwyg');
 	});
 
 	test('button要素は分類対象外でwysiwygになる', () => {

--- a/packages/@d-zero/site-migrator/src/page-extractor/classify-block-item.ts
+++ b/packages/@d-zero/site-migrator/src/page-extractor/classify-block-item.ts
@@ -110,14 +110,18 @@ const GOOGLE_MAPS_HOST_PATTERN = /google\.\w+\/maps/;
  *    image/youtube/google-maps/download-file/button/title-h2/title-h3を試す。
  *    いずれにも該当しなければ `wysiwyg`。
  *
- * **重大な制約**: anatomistの`LayoutBlock`/`RawLayoutNode`は要素の属性（`href`/`src`/
- * `srcset`/`alt`/`width`/`height`等）を保持しない（`tagName`/`id`/`classList`/`boundingBox`/
- * `style`/`innerHTML`/`children`のみ）。加えて`should-recurse.ts`のcollapseロジックにより
- * `<picture><source><img></picture>`のようなラッパー構造は最終的に`img`自身（void要素、
- * `innerHTML`は空）だけが残る。そのため実データでは`image`/`youtube`/`google-maps`/
- * `download-file`/`button.link`の判定条件（src/href）がほぼ常に取得できず、safeに`wysiwyg`
- * へフォールバックする。これはバグではなく、属性情報が存在しないデータに対する意図された
- * 安全側の挙動である。anatomist側の属性キャプチャ拡張は別途フォローアップ課題として扱う。
+ * **`block`自身のタグが`<a>`/`<img>`/`<iframe>`になったケース**: `should-recurse.ts`の
+ * collapseロジックにより`<picture><source><img></picture>`のようなラッパー構造は最終的に
+ * `img`自身（void要素、`innerHTML`は空）だけが残ることがある。`@d-zero/anatomist`
+ * 0.3.0以降、`LayoutBlock.attributes`（`href`/`src`/`srcset`/`action`/`alt`/`target`/
+ * `download`の固定allowlist、生値のまま）経由でこのケースの`href`/`src`を取得できる
+ * （それ以前のバージョンでは`attributes`が`undefined`になり、常に`wysiwyg`へ
+ * フォールバックしていた）。ただし`width`/`height`/`loading`/iframeの`title`属性は
+ * allowlist外のため未取得のまま（`image`アイテムは`width`/`height`を`0`、`loading`を
+ * `'eager'`固定でフォールバックする）。また、`<a href><picture>…</picture></a>`のように
+ * ラッパー側（子ではなく祖先）が属性を持つケースは、collapseで祖先自体が消えるため
+ * `attributes`があっても引き続き救済されない（祖先の属性を`collapsedFrom`のような形で
+ * 保持する仕組みが別途必要）。
  * @param block
  * @example
  * ```ts
@@ -151,12 +155,13 @@ export function classifyBlockItem(block: LayoutBlock): ClassifiedBlockItem {
 	}
 
 	if (selfTag === 'a') {
-		// ブロック自身がaの場合、collapseによりhref/親要素の情報は失われている
-		// （LayoutBlockにhrefフィールドが存在しないため常にundefined）。
+		// ブロック自身がaの場合、collapseにより親要素の情報は失われているが、`href`自身は
+		// `block.attributes`（anatomist 0.3.0+）から取得できる（無ければ`undefined`のまま
+		// classifyAnchorLikeへ渡り、従来通りwysiwygへフォールバックする）。
 		return (
 			classifyAnchorLike(
 				block.classList,
-				undefined,
+				block.attributes?.href,
 				extractTextContent(parseFragment(block.innerHTML)),
 				[],
 			) ?? wysiwygItem(block)
@@ -171,9 +176,20 @@ export function classifyBlockItem(block: LayoutBlock): ClassifiedBlockItem {
 		return wysiwygItem(block);
 	}
 
-	if (selfTag === 'img' || selfTag === 'iframe') {
-		// img: void要素なのでinnerHTMLは常に空。iframe: srcはLayoutBlockに保存されない。
-		// いずれも属性を読む手段が無いため即フォールバック。
+	if (selfTag === 'img') {
+		// img: void要素なのでinnerHTMLは常に空。`src`は`block.attributes`から取得する。
+		const image = buildImageItemFromAttributes(block.attributes);
+		if (image) {
+			return image;
+		}
+		return wysiwygItem(block);
+	}
+
+	if (selfTag === 'iframe') {
+		const iframeItem = classifyIframeLike(block.attributes?.src);
+		if (iframeItem) {
+			return iframeItem;
+		}
 		return wysiwygItem(block);
 	}
 
@@ -197,18 +213,12 @@ export function classifyBlockItem(block: LayoutBlock): ClassifiedBlockItem {
 	}
 
 	if (tag === 'iframe') {
-		const src = getAttr(element, 'src');
-		if (src === undefined) {
-			return wysiwygItem(block);
-		}
-		if (YOUTUBE_HOST_PATTERN.test(src)) {
-			return buildYoutubeItem(src, getAttr(element, 'title'));
-		}
-		if (GOOGLE_MAPS_HOST_PATTERN.test(src)) {
-			const googleMaps = extractGoogleMaps(src);
-			if (googleMaps) {
-				return googleMaps;
-			}
+		const iframeItem = classifyIframeLike(
+			getAttr(element, 'src'),
+			getAttr(element, 'title'),
+		);
+		if (iframeItem) {
+			return iframeItem;
 		}
 		return wysiwygItem(block);
 	}
@@ -403,6 +413,33 @@ function extractGoogleMaps(
 }
 
 /**
+ * `<iframe>`（子要素として現れるケース・ブロック自身のタグになったケースの両方）を
+ * youtube/google-mapsへ分類する共通ロジック。`src`が無い、またはいずれのホストパターンにも
+ * マッチしない場合は`undefined`を返し、呼び出し側が`wysiwyg`にフォールバックする。
+ * @param src
+ * @param title - 省略可（`selfTag==='iframe'`のcollapseケースはanatomistの`attributes`
+ *   allowlistに`title`が含まれないため常に未取得。省略時はbuildYoutubeItemが既定タイトルを使う）。
+ */
+function classifyIframeLike(
+	src: string | undefined,
+	title?: string,
+):
+	| { name: 'youtube'; data: YoutubeItemData }
+	| { name: 'google-maps'; data: GoogleMapsItemData }
+	| undefined {
+	if (src === undefined) {
+		return undefined;
+	}
+	if (YOUTUBE_HOST_PATTERN.test(src)) {
+		return buildYoutubeItem(src, title);
+	}
+	if (GOOGLE_MAPS_HOST_PATTERN.test(src)) {
+		return extractGoogleMaps(src);
+	}
+	return undefined;
+}
+
+/**
  * `<picture>`配下の`<source>`/`<img>`を文書順に1エントリとして拾い、`path`/`alt`/`width`/
  * `height`/`media`/`loading`の配列を構築する。`path`が1件も取れない場合（属性を持つ
  * `<source>`/`<img>`が実際には無い、実データで高頻度に起きるケース）は`undefined`を返し、
@@ -493,6 +530,34 @@ function extractImageFromImgElement(
 			height: [toNumberOrFallback(getAttr(element, 'height'))],
 			media: [''],
 			loading: [normalizeLoading(getAttr(element, 'loading'))],
+		},
+	};
+}
+
+/**
+ * `extractImageFromImgElement`と同じデータ形を、parse5の`Element`ではなく`block.attributes`
+ * （anatomist 0.3.0+、`img`自身がブロックのルートタグになったcollapseケース向け）から
+ * 直接組み立てる。allowlistに`width`/`height`/`loading`が含まれないため、これらは常に
+ * フォールバック値（`0`/`'eager'`）になる — `src`/`alt`が取れるだけでも、従来の
+ * 無条件`wysiwyg`フォールバックより情報量が増える。
+ * @param attributes
+ */
+function buildImageItemFromAttributes(
+	attributes: Readonly<Record<string, string>> | undefined,
+): { name: 'image'; data: ImageEntryData } | undefined {
+	const src = attributes?.src;
+	if (src === undefined) {
+		return undefined;
+	}
+	return {
+		name: 'image',
+		data: {
+			path: [src],
+			alt: [attributes?.alt ?? ''],
+			width: [toNumberOrFallback(attributes?.width)],
+			height: [toNumberOrFallback(attributes?.height)],
+			media: [''],
+			loading: [normalizeLoading(attributes?.loading)],
 		},
 	};
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1355,18 +1355,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@d-zero/anatomist@npm:0.2.0":
-  version: 0.2.0
-  resolution: "@d-zero/anatomist@npm:0.2.0"
+"@d-zero/anatomist@npm:0.3.0":
+  version: 0.3.0
+  resolution: "@d-zero/anatomist@npm:0.3.0"
   dependencies:
-    "@d-zero/beholder": "npm:4.2.0"
-    "@d-zero/dealer": "npm:1.10.2"
-    "@d-zero/puppeteer-page-scan": "npm:4.6.6"
-    "@d-zero/shared": "npm:0.22.3"
+    "@d-zero/beholder": "npm:4.2.1"
+    "@d-zero/dealer": "npm:1.10.3"
+    "@d-zero/puppeteer-page-scan": "npm:4.6.7"
+    "@d-zero/shared": "npm:0.22.4"
     puppeteer: "npm:25.3.0"
   bin:
     anatomist: dist/cli.js
-  checksum: 10c0/e868dd20dc0bfc51dfa842d50f60e53545eb1c86da1c26f9f331f1b0521b246e324dbbf2f9a65f8bd67eb602f6eaaa49b129f53a4d41425f56e679a48dea6999
+  checksum: 10c0/d3b14afbc7ef6431adad02fac8100d43fe04d2fad921ed6964f291499d6485c5e7ab4c63dbfb70cc3a866a544be289c23c6e47e16922b0d73550b734ecf98d7c
   languageName: node
   linkType: hard
 
@@ -1383,16 +1383,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@d-zero/beholder@npm:4.2.0":
-  version: 4.2.0
-  resolution: "@d-zero/beholder@npm:4.2.0"
+"@d-zero/beholder@npm:4.2.1":
+  version: 4.2.1
+  resolution: "@d-zero/beholder@npm:4.2.1"
   dependencies:
-    "@d-zero/puppeteer-page-scan": "npm:4.6.6"
-    "@d-zero/shared": "npm:0.22.3"
+    "@d-zero/puppeteer-page-scan": "npm:4.6.7"
+    "@d-zero/shared": "npm:0.22.4"
     debug: "npm:4.4.3"
     puppeteer: "npm:25.3.0"
     simple-wappalyzer: "npm:1.1.100"
-  checksum: 10c0/474a204ba63eec82d0c6d1bcff0ec8304b973d7b1b008ed8324a2cbe089a9147bf44c75cb406d36762867e481bc181b046f88b4c35f743e9190f57d9e9869b53
+  checksum: 10c0/c351d67f55092edac47b7605e8fa0e15b152d5f6521c92d07751eacf9ecc973ba5f48460aa31daa7200479845bea58316bfdf26ad98a5e6453dd2cd5608ff303
   languageName: node
   linkType: hard
 
@@ -1488,13 +1488,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@d-zero/dealer@npm:1.10.2":
-  version: 1.10.2
-  resolution: "@d-zero/dealer@npm:1.10.2"
+"@d-zero/dealer@npm:1.10.3":
+  version: 1.10.3
+  resolution: "@d-zero/dealer@npm:1.10.3"
   dependencies:
-    "@d-zero/shared": "npm:0.22.3"
+    "@d-zero/shared": "npm:0.22.4"
     ansi-colors: "npm:4.1.3"
-  checksum: 10c0/12bee8088d31ccb123d294a81fcf4f451c71a347b29e2b1e5d9df527872e36ae94377bf537662088ce0a7a425df06184e54fe8d213841ccd5a7a1c4d49797c90
+  checksum: 10c0/0c09e58df84822fde6fdf71c4cf8cf37aac273d6089010664553749d485ad8a0d85e7680124df98dbadd8a6edf24836b6765e54b83a50075f11f5488ef21f77c
   languageName: node
   linkType: hard
 
@@ -1654,16 +1654,27 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@d-zero/puppeteer-page-scan@npm:4.6.6":
-  version: 4.6.6
-  resolution: "@d-zero/puppeteer-page-scan@npm:4.6.6"
+"@d-zero/puppeteer-page-scan@npm:4.6.7":
+  version: 4.6.7
+  resolution: "@d-zero/puppeteer-page-scan@npm:4.6.7"
   dependencies:
     "@d-zero/puppeteer-general-actions": "npm:1.2.6"
-    "@d-zero/puppeteer-scroll": "npm:4.0.9"
-    "@d-zero/shared": "npm:0.22.3"
+    "@d-zero/puppeteer-scroll": "npm:4.0.10"
+    "@d-zero/shared": "npm:0.22.4"
   peerDependencies:
     puppeteer: 25.2.1
-  checksum: 10c0/0257fe21786a55a2c59e3961c8551819a166d951b4a41f728cc37ea5e22093556c58e22ea97ad34a16235e6707744a73d1c50af5751d8bd2823ee17503054ef2
+  checksum: 10c0/033dfe2c6f180aab1af4baccb6db1909bc3c1f633ab502de4b13d769dd9ac61de44232887c7423a50dc97b54248233d8abb1996216ac2915e3ee58cd292819ff
+  languageName: node
+  linkType: hard
+
+"@d-zero/puppeteer-scroll@npm:4.0.10":
+  version: 4.0.10
+  resolution: "@d-zero/puppeteer-scroll@npm:4.0.10"
+  dependencies:
+    "@d-zero/shared": "npm:0.22.4"
+  peerDependencies:
+    puppeteer: 25.2.1
+  checksum: 10c0/c32f2cb0eadcc37ae236e582568c00bd4a41ba75ebbc5ef54591157bafb0eab1b325a3973d3a50174c161dbc90025f8de52ed675fb423050c6a76d176e27b23c
   languageName: node
   linkType: hard
 
@@ -1675,17 +1686,6 @@ __metadata:
   peerDependencies:
     puppeteer: 24.37.5
   checksum: 10c0/07234339cf3466a05abd0bd754864f1625291f263784685722ae52ce227838ce21d4e6ee3cbcdb21bb8c03a5ea094feed36d2c74ea5d4b321adc30d5ab02ed1d
-  languageName: node
-  linkType: hard
-
-"@d-zero/puppeteer-scroll@npm:4.0.9":
-  version: 4.0.9
-  resolution: "@d-zero/puppeteer-scroll@npm:4.0.9"
-  dependencies:
-    "@d-zero/shared": "npm:0.22.3"
-  peerDependencies:
-    puppeteer: 25.2.1
-  checksum: 10c0/5a6401b15368b233cc83cc66fcc7075f00db2dcba3e38560c8422408e067ea5c3fe569118ba90fd5bb6cdbcfaa327e6368654ab5372f0d6f33a27f186b17a80a
   languageName: node
   linkType: hard
 
@@ -1810,9 +1810,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@d-zero/shared@npm:0.22.3":
-  version: 0.22.3
-  resolution: "@d-zero/shared@npm:0.22.3"
+"@d-zero/shared@npm:0.22.4":
+  version: 0.22.4
+  resolution: "@d-zero/shared@npm:0.22.4"
   dependencies:
     "@holiday-jp/holiday_jp": "npm:2.5.1"
     await-event-emitter: "npm:2.0.2"
@@ -1821,7 +1821,7 @@ __metadata:
     front-matter: "npm:4.0.2"
     micromatch: "npm:4.0.8"
     sanitize-filename: "npm:1.6.4"
-  checksum: 10c0/2458def65fafe5e0ae652132ef0cafc862974245779d88808ec1c35a5dba4ec2e5a82a32c6d631241612ded2daae5207602593161d68b521af824b0f7dd91aaa
+  checksum: 10c0/a853a6abb0511ef0be130e79ab449566dd640caa12627d182c15864b5679fdd9894688d5c35bf14f9395b2cf743be75d077493c1ca5da4a6e9f91e670ca8e206
   languageName: node
   linkType: hard
 
@@ -1831,7 +1831,7 @@ __metadata:
   dependencies:
     "@burger-editor/blocks": "npm:4.0.0-alpha.70"
     "@burger-editor/core": "npm:4.0.0-alpha.70"
-    "@d-zero/anatomist": "npm:0.2.0"
+    "@d-zero/anatomist": "npm:0.3.0"
     "@d-zero/dealer": "npm:1.10.1"
     "@d-zero/shared": "npm:0.22.2"
     "@nitpicker/crawler": "npm:0.11.0"


### PR DESCRIPTION
## Summary

- Bumps `@d-zero/anatomist` to `0.3.0`, which added `LayoutBlock.attributes` (a fixed allowlist: `href`/`src`/`srcset`/`action`/`alt`/`target`/`download`, captured verbatim, see `d-zero-dev/tools#941`).
- `classifyBlockItem` previously fell back to `wysiwyg` unconditionally whenever `should-recurse.ts`'s collapse logic made an `<a>`/`<img>`/`<iframe>` element the classified block's own root tag, because `href`/`src` were structurally unrecoverable from `LayoutBlock` before this anatomist version.
- Uses `block.attributes` to resolve `button`/`download-file` links, `image` src/alt, and `iframe` youtube/google-maps src for that collapse case. The youtube/google-maps matching logic is shared (`classifyIframeLike`) between this new self-tag path and the existing child-element path — the refactor is behavior-preserving (existing child-iframe tests pass unchanged).
- `width`/`height`/`loading` and iframe `title` stay outside anatomist's allowlist and keep their existing fallback values (`0`/`'eager'`/default title). Wrapper elements whose attributes are lost to an *ancestor* collapse (rather than becoming the block's own tag, e.g. `<a href><picture>…</picture></a>`) remain unresolved — that needs ancestor-attribute tracking anatomist doesn't do yet.
- Updates `README.md`'s "既知の制限" section to reflect the (partial) resolution instead of the old blanket "ほぼ常に取得できない" description.

## Test plan

- [x] `yarn build` — passes
- [x] `yarn test` — 319 tests pass (10 new: collapse-case coverage for `<a>`/`<img>`/`<iframe>` with/without attributes, including alt-fallback and google-maps-via-attributes cases added per QA review)
- [x] `yarn lint` — passes (0 errors; pre-existing warnings unrelated to this change)
- [x] `/code-review medium` — 0 findings
- [x] `/qa-engineer` — 3 coverage gaps found and fixed (untested wysiwyg-fallback wiring for `selfTag==='a'`/`'iframe'`, untested `alt` default-fallback)
- [x] `/product-manager` — 0 findings (doc/README consistency verified against implementation; package is pre-1.0/`-alpha.*`, so no migration guide required)
