### PR TITLE
feat(site-migrator): add --include option to dz-migrate

### DIFF
--- a/packages/@d-zero/site-migrator/README.md
+++ b/packages/@d-zero/site-migrator/README.md
@@ -11,7 +11,7 @@ yarn add @d-zero/site-migrator
 ## CLI
 
 ```sh
-npx dz-migrate <archive.nitpicker> -o <htdocs-dir> --content-class <name> [--layout-json <path>] [--limit <n>] [--extract-limit <n>]
+npx dz-migrate <archive.nitpicker> -o <htdocs-dir> --content-class <name> [--layout-json <path>] [--limit <n>] [--extract-limit <n>] [--include <path>]...
 ```
 
 - `<archive.nitpicker>` — [nitpicker](https://github.com/d-zero-dev/nitpicker) で生成済みのアーカイブファイル
@@ -20,6 +20,7 @@ npx dz-migrate <archive.nitpicker> -o <htdocs-dir> --content-class <name> [--lay
 - `--layout-json <path>` — 事前生成済みの anatomist レイアウト解析 JSONL（1 ファイルで対象 URL 全件分）。省略時は全ページをライブ解析する
 - `--limit <n>` — 並列 DL 数（デフォルト 10）
 - `--extract-limit <n>` — 並列ページ抽出数（デフォルト 10）。ライブレイアウト解析の並列数もこれを共用する
+- `--include <path>` — 移行対象ページの絞り込み（複数指定可、和集合）。値は `/` 始まりの pathname、または `http(s)://` の完全 URL（pathname 部のみ使用、ホストは無視）。末尾が `/` の値はそのディレクトリ配下＋index ページ自身へのプレフィックス一致、それ以外は pathname の完全一致（`?query` / `#fragment` は比較対象外で、それらを含む値自体はエラー）。`--include /` や `--include https://example.com`（pathname が `/` になる値）はプレフィックス一致ルールの帰結として全ページ一致＝フィルタなしと等価になる。リソースの DL は常に全件。1 ページもマッチしない値が 1 つでもあれば、その値をすべて列挙して何も DL・書き出しせずに exit code 2 で終了する。id 採番の母集合は常にアーカイブ全ページのため、部分実行でも id と `{{<id>}}` 参照は全体実行と完全に一致する（後述）
 
 リソースは fetch で DL、ページ HTML はアーカイブ内のスナップショットを読み、`extractMainContent` でレイアウト共通部分を剥がし、そのページのレイアウトを BurgerEditor ブロックへ変換して既存 main 要素へ埋め込み（後述）、`assignPageIds` で URL → 整数 id の写像を組み立てて `.nitpicker` DB のページメタと併せて `formatFrontmatter` が生成する `---\n…\n---\n` YAML ブロックを先頭に prepend、本文中の同一オリジン参照を `rewritePageRefs` が書き換えてから `.html` として書き出す。
 
@@ -44,30 +45,34 @@ import {
 	buildPageIdLookup,
 	rewritePageRefs,
 	resolveIdTemplate,
+	parseIncludePattern,
+	filterUrlsByInclude,
 } from '@d-zero/site-migrator';
 ```
 
 主要 API:
 
-| 関数                    | 概要                                                                                      |
-| ----------------------- | ----------------------------------------------------------------------------------------- |
-| `migrate`               | アーカイブを開き、リソース DL とページ抽出を並列実行する全体フロー                        |
-| `openArchive`           | `.nitpicker` を開いてセッションを返す（要 `close()`）                                     |
-| `listInternalPages`     | 内部ページ URL を順に yield する非同期イテラブル                                          |
-| `listInternalResources` | 内部リソース URL を順に yield する非同期イテラブル                                        |
-| `getPageHtml`           | レンダリング後 HTML を全長で取得（truncate なし）                                         |
-| `getFrontmatter`        | `.nitpicker` DB の flat meta カラムを `Frontmatter` へマップ                              |
-| `downloadResources`     | URL リストを並列 fetch してローカルへ保存                                                 |
-| `urlToOutputPath`       | URL を `<htdocs-dir>` 配下のローカルパスへ変換                                            |
-| `rewriteAssetRefs`      | HTML 内のアセット参照を resolver で書き換える（streaming）                                |
-| `extractMainContent`    | レイアウト共通部分を剥がして本文要素の `outerHTML` を返す                                 |
-| `extractPages`          | ページ一覧に `extractMainContent` + `getFrontmatter` を適用して書き出す                   |
-| `formatFrontmatter`     | `Frontmatter` を後段パイプライン互換の `---\n…\n---\n` YAML ブロック文字列にする          |
-| `splitTitle`            | タイトル文字列を `｜` / `\|` で分割し `{title, rawTitle?}` を返す純関数                   |
-| `assignPageIds`         | URL リストから ディレクトリグループ採番ルールに従って `Map<url, id>` を組み立てる純関数   |
-| `buildPageIdLookup`     | `assignPageIds` の結果から `rewritePageRefs` 用ルックアップ表を一度だけ構築する純関数     |
-| `rewritePageRefs`       | 同一オリジンの asset/page 参照を root-relative path / `{{<id>}}` テンプレートに書き換える |
-| `resolveIdTemplate`     | `{{<id>}}` token を id→URL マップで実 URL に解決する純関数（後段ビルドツール用）          |
+| 関数                    | 概要                                                                                                |
+| ----------------------- | --------------------------------------------------------------------------------------------------- |
+| `migrate`               | アーカイブを開き、リソース DL とページ抽出を並列実行する全体フロー                                  |
+| `parseIncludePattern`   | `--include` 生値 1 個を pathname プレフィックス/完全一致パターンへ解釈する純関数                    |
+| `filterUrlsByInclude`   | `--include` 値のリストでページ URL リストを絞り込む純関数。未マッチ値があれば `IncludeNoMatchError` |
+| `openArchive`           | `.nitpicker` を開いてセッションを返す（要 `close()`）                                               |
+| `listInternalPages`     | 内部ページ URL を順に yield する非同期イテラブル                                                    |
+| `listInternalResources` | 内部リソース URL を順に yield する非同期イテラブル                                                  |
+| `getPageHtml`           | レンダリング後 HTML を全長で取得（truncate なし）                                                   |
+| `getFrontmatter`        | `.nitpicker` DB の flat meta カラムを `Frontmatter` へマップ                                        |
+| `downloadResources`     | URL リストを並列 fetch してローカルへ保存                                                           |
+| `urlToOutputPath`       | URL を `<htdocs-dir>` 配下のローカルパスへ変換                                                      |
+| `rewriteAssetRefs`      | HTML 内のアセット参照を resolver で書き換える（streaming）                                          |
+| `extractMainContent`    | レイアウト共通部分を剥がして本文要素の `outerHTML` を返す                                           |
+| `extractPages`          | ページ一覧に `extractMainContent` + `getFrontmatter` を適用して書き出す                             |
+| `formatFrontmatter`     | `Frontmatter` を後段パイプライン互換の `---\n…\n---\n` YAML ブロック文字列にする                    |
+| `splitTitle`            | タイトル文字列を `｜` / `\|` で分割し `{title, rawTitle?}` を返す純関数                             |
+| `assignPageIds`         | URL リストから ディレクトリグループ採番ルールに従って `Map<url, id>` を組み立てる純関数             |
+| `buildPageIdLookup`     | `assignPageIds` の結果から `rewritePageRefs` 用ルックアップ表を一度だけ構築する純関数               |
+| `rewritePageRefs`       | 同一オリジンの asset/page 参照を root-relative path / `{{<id>}}` テンプレートに書き換える           |
+| `resolveIdTemplate`     | `{{<id>}}` token を id→URL マップで実 URL に解決する純関数（後段ビルドツール用）                    |
 
 `Frontmatter` の出力構造は [`./src/types.ts`](./src/types.ts) を参照。`title` / `og.title` / `twitter.title` は `｜` `|` で分割して最初の非空セグメントを採用し、分割が起きたときだけ `rawTitle` 等に元文字列を保持する。
 
@@ -95,7 +100,7 @@ import {
 
 ### ページ id 採番と参照書き換え
 
-`extractPages` は処理開始時に `items` の全 URL を `assignPageIds` に渡して URL → 整数 id の写像を組み立てる。各ページの frontmatter には `id: <number>` がトップに埋め込まれ、本文中の同一オリジン参照は `rewritePageRefs` が次のルールで書き換える。
+`extractPages` は処理開始時に `idUrls`（省略時は `items`）の全 URL を `assignPageIds` に渡して URL → 整数 id の写像を組み立てる。各ページの frontmatter には `id: <number>` がトップに埋め込まれ、本文中の同一オリジン参照は `rewritePageRefs` が次のルールで書き換える。`dz-migrate` は `--include` 指定の有無に関わらず**アーカイブの全ページ URL** を `idUrls` として渡すので、部分移行（`--include` で `items` を絞り込んだ場合）でも各ページの id は全体移行時と一致し、フィルタ対象外ページへの `<a href>` も root-relative フォールバックではなく `{{<id>}}` に書き換わる（未解決の id は後段の `resolveIdTemplate` の `onUnresolved` で検出できる）。
 
 採番ルール:
 

--- a/packages/@d-zero/site-migrator/src/cli.ts
+++ b/packages/@d-zero/site-migrator/src/cli.ts
@@ -1,10 +1,11 @@
 #!/usr/bin/env node
 import { parseArgs } from 'node:util';
 
+import { IncludeNoMatchError, parseIncludePattern } from './include-filter.js';
 import { migrate } from './migrate.js';
 
 const USAGE = `Usage:
-  dz-migrate <archive.nitpicker> -o <htdocs-dir> --content-class <name> [--layout-json <path>] [--limit <n>] [--extract-limit <n>]
+  dz-migrate <archive.nitpicker> -o <htdocs-dir> --content-class <name> [--layout-json <path>] [--limit <n>] [--extract-limit <n>] [--include <path>]...
 
 Downloads sub-resources from the archive and, for each internal page, strips
 the shared layout, assigns a stable integer id, prepends a YAML frontmatter
@@ -27,6 +28,14 @@ Options:
   --limit <n>                    Concurrent resource download limit (default: 10).
   --extract-limit <n>            Concurrent page extraction limit (default: 10). Also shared
                                  by live layout analysis concurrency.
+  --include <path>               Restrict page extraction to matching pages. Repeatable
+                                 (union). "/dir/" (trailing slash) selects the directory
+                                 subtree including its index page; any other value selects
+                                 the single page whose pathname matches exactly. Full
+                                 http(s):// URLs are accepted — only the pathname is used.
+                                 A value matching no page aborts with exit 2 before any
+                                 download or write. Resources are always downloaded in
+                                 full, and page ids stay identical to an unfiltered run.
   -h, --help                     Show this help message.
 `;
 
@@ -47,6 +56,7 @@ async function main(argv: readonly string[]): Promise<number> {
 				'layout-json': { type: 'string' },
 				limit: { type: 'string' },
 				'extract-limit': { type: 'string' },
+				include: { type: 'string', multiple: true },
 				help: { type: 'boolean', short: 'h', default: false },
 			},
 		});
@@ -99,6 +109,18 @@ async function main(argv: readonly string[]): Promise<number> {
 		return 2;
 	}
 
+	const include = parsed.values.include;
+	if (include) {
+		for (const value of include) {
+			try {
+				parseIncludePattern(value);
+			} catch (error) {
+				process.stderr.write(`Error: ${(error as Error).message}\n\n${USAGE}`);
+				return 2;
+			}
+		}
+	}
+
 	const controller = new AbortController();
 	const onSigint = () => controller.abort();
 	process.on('SIGINT', onSigint);
@@ -111,7 +133,13 @@ async function main(argv: readonly string[]): Promise<number> {
 			layoutJsonPath,
 			downloadLimit,
 			extractLimit,
+			include,
 			signal: controller.signal,
+			onInclude: (event) => {
+				process.stdout.write(
+					`Include: ${event.selected} of ${event.total} pages selected\n`,
+				);
+			},
 			onResource: (event) => {
 				if (event.outcome === 'failed') {
 					process.stderr.write(`fail: ${event.url} — ${event.error.message}\n`);
@@ -178,6 +206,16 @@ async function main(argv: readonly string[]): Promise<number> {
 			return 130;
 		}
 		return report.resourcesFailed === 0 && report.pagesFailed === 0 ? 0 : 1;
+	} catch (error) {
+		// `InvalidIncludeValueError` is not caught here: every `--include` value
+		// was already run through the same `parseIncludePattern` above, so by
+		// the time `migrate()` re-parses it via `filterUrlsByInclude`, it cannot
+		// throw that error again (deterministic, pure function, same input).
+		if (error instanceof IncludeNoMatchError) {
+			process.stderr.write(`Error: ${error.message}\n`);
+			return 2;
+		}
+		throw error;
 	} finally {
 		process.off('SIGINT', onSigint);
 		process.off('SIGTERM', onSigint);

--- a/packages/@d-zero/site-migrator/src/include-filter.spec.ts
+++ b/packages/@d-zero/site-migrator/src/include-filter.spec.ts
@@ -1,0 +1,214 @@
+import { describe, expect, test } from 'vitest';
+
+import {
+	filterUrlsByInclude,
+	IncludeNoMatchError,
+	InvalidIncludeValueError,
+	parseIncludePattern,
+} from './include-filter.js';
+
+describe('parseIncludePattern', () => {
+	test('parses a pathname prefix', () => {
+		expect(parseIncludePattern('/news/')).toStrictEqual({
+			pathname: '/news/',
+			isPrefix: true,
+			raw: '/news/',
+		});
+	});
+
+	test('parses a pathname exact match', () => {
+		expect(parseIncludePattern('/news/a.html')).toStrictEqual({
+			pathname: '/news/a.html',
+			isPrefix: false,
+			raw: '/news/a.html',
+		});
+	});
+
+	test('parses a full https URL, ignoring the host', () => {
+		expect(parseIncludePattern('https://example.com/news/')).toStrictEqual({
+			pathname: '/news/',
+			isPrefix: true,
+			raw: 'https://example.com/news/',
+		});
+	});
+
+	test('parses a full http URL, ignoring the host', () => {
+		expect(parseIncludePattern('http://other.example/page.html')).toStrictEqual({
+			pathname: '/page.html',
+			isPrefix: false,
+			raw: 'http://other.example/page.html',
+		});
+	});
+
+	test('a host-only URL normalises to the root prefix pattern', () => {
+		expect(parseIncludePattern('https://example.com')).toStrictEqual({
+			pathname: '/',
+			isPrefix: true,
+			raw: 'https://example.com',
+		});
+	});
+
+	test('a full URL without trailing slash is an exact match', () => {
+		expect(parseIncludePattern('https://example.com/news')).toStrictEqual({
+			pathname: '/news',
+			isPrefix: false,
+			raw: 'https://example.com/news',
+		});
+	});
+
+	test('percent-encodes non-ASCII segments the same way page URLs do', () => {
+		const pattern = parseIncludePattern('/ニュース/');
+		expect(pattern.pathname).toBe('/%E3%83%8B%E3%83%A5%E3%83%BC%E3%82%B9/');
+		expect(pattern.isPrefix).toBe(true);
+	});
+
+	test('resolves `.` / `..` segments like a browser would', () => {
+		expect(parseIncludePattern('/a/../b.html').pathname).toBe('/b.html');
+	});
+
+	test('rejects a value not starting with "/" or "http(s)://"', () => {
+		expect(() => parseIncludePattern('news/')).toThrow(InvalidIncludeValueError);
+	});
+
+	test('rejects an empty string', () => {
+		expect(() => parseIncludePattern('')).toThrow(InvalidIncludeValueError);
+	});
+
+	test('rejects a non-http(s) scheme', () => {
+		expect(() => parseIncludePattern('ftp://example.com/x')).toThrow(
+			InvalidIncludeValueError,
+		);
+	});
+
+	test('rejects a value with a query string', () => {
+		expect(() => parseIncludePattern('/news/?p=1')).toThrow(InvalidIncludeValueError);
+	});
+
+	test('rejects a value with a fragment', () => {
+		expect(() => parseIncludePattern('/news/#top')).toThrow(InvalidIncludeValueError);
+	});
+
+	test('rejects a protocol-relative value instead of reading the first segment as a host', () => {
+		// Without this guard, `new URL('//news/index.html', base)` treats `news`
+		// as the hostname and silently yields pathname `/index.html`.
+		expect(() => parseIncludePattern('//news/index.html')).toThrow(
+			InvalidIncludeValueError,
+		);
+	});
+
+	test('rejects an http(s)-prefixed value that the URL parser cannot construct', () => {
+		// `https://` matches the `^https?:\/\//` prefix check but has no host,
+		// so `new URL(raw)` itself throws — exercises the inner catch branch.
+		expect(() => parseIncludePattern('https://')).toThrow(InvalidIncludeValueError);
+	});
+});
+
+describe('filterUrlsByInclude', () => {
+	test('a prefix pattern selects the subtree and its index page, not siblings', () => {
+		const urls = [
+			'https://example.com/news/',
+			'https://example.com/news/a.html',
+			'https://example.com/news/2024/b.html',
+			'https://example.com/newsroom/x.html',
+			'https://example.com/news',
+		];
+
+		expect(filterUrlsByInclude(['/news/'], urls)).toStrictEqual([
+			'https://example.com/news/',
+			'https://example.com/news/a.html',
+			'https://example.com/news/2024/b.html',
+		]);
+	});
+
+	test('an exact pattern selects only the matching pathname, ignoring the query', () => {
+		const urls = [
+			'https://example.com/list?p=1',
+			'https://example.com/list?p=2',
+			'https://example.com/list/',
+			'https://example.com/list.html',
+		];
+
+		expect(filterUrlsByInclude(['/list'], urls)).toStrictEqual([
+			'https://example.com/list?p=1',
+			'https://example.com/list?p=2',
+		]);
+	});
+
+	test('multiple values union, dedupe overlapping matches, and preserve input order', () => {
+		const urls = [
+			'https://example.com/news/',
+			'https://example.com/news/a.html',
+			'https://example.com/about/',
+		];
+
+		expect(
+			filterUrlsByInclude(['/news/', '/news/a.html', '/about/'], urls),
+		).toStrictEqual(urls);
+	});
+
+	test('a duplicated include value does not change the result or error', () => {
+		const urls = ['https://example.com/news/', 'https://example.com/about/'];
+
+		expect(filterUrlsByInclude(['/news/', '/news/'], urls)).toStrictEqual([
+			'https://example.com/news/',
+		]);
+	});
+
+	test('pathname comparison is case-sensitive', () => {
+		const urls = ['https://example.com/news/x.html'];
+
+		expect(() => filterUrlsByInclude(['/News/'], urls)).toThrow(IncludeNoMatchError);
+	});
+
+	test('the include value host is ignored — matching is pathname-only', () => {
+		const urls = ['https://example.com/about/'];
+
+		expect(filterUrlsByInclude(['https://other.example/about/'], urls)).toStrictEqual([
+			'https://example.com/about/',
+		]);
+	});
+
+	test('lists every unmatched raw value, not just the first', () => {
+		const urls = ['https://example.com/news/'];
+
+		expect(() => filterUrlsByInclude(['/news/', '/nope/', '/also-nope/'], urls)).toThrow(
+			IncludeNoMatchError,
+		);
+		try {
+			filterUrlsByInclude(['/news/', '/nope/', '/also-nope/'], urls);
+			expect.unreachable();
+		} catch (error) {
+			expect(error).toBeInstanceOf(IncludeNoMatchError);
+			expect((error as IncludeNoMatchError).unmatched).toStrictEqual([
+				'/nope/',
+				'/also-nope/',
+			]);
+		}
+	});
+
+	test('an invalid value throws before any matching happens', () => {
+		expect(() => filterUrlsByInclude(['news/'], ['https://example.com/'])).toThrow(
+			InvalidIncludeValueError,
+		);
+	});
+
+	test('an unparsable page URL is treated as matching nothing, not thrown', () => {
+		const urls = ['not a url', 'https://example.com/news/'];
+
+		expect(filterUrlsByInclude(['/news/'], urls)).toStrictEqual([
+			'https://example.com/news/',
+		]);
+	});
+
+	test('the root pattern "/" selects every page', () => {
+		const urls = ['https://example.com/', 'https://example.com/about/'];
+
+		expect(filterUrlsByInclude(['/'], urls)).toStrictEqual(urls);
+	});
+
+	test('an empty include list selects every URL unchanged, without error', () => {
+		const urls = ['https://example.com/', 'not a url', 'https://example.com/about/'];
+
+		expect(filterUrlsByInclude([], urls)).toStrictEqual(urls);
+	});
+});

--- a/packages/@d-zero/site-migrator/src/include-filter.ts
+++ b/packages/@d-zero/site-migrator/src/include-filter.ts
@@ -1,0 +1,196 @@
+/**
+ * Single `--include` pattern parsed from a CLI-style raw value.
+ */
+export interface IncludePattern {
+	/** Normalised pathname (run through the URL parser, so percent-encoding matches page URLs). */
+	readonly pathname: string;
+	/** `true` when `raw` ended with `/` — pathname prefix match; `false` — exact match. */
+	readonly isPrefix: boolean;
+	/** The original CLI value, kept for error messages. */
+	readonly raw: string;
+}
+
+/**
+ * Thrown by {@link parseIncludePattern} when a raw `--include` value cannot be
+ * interpreted as a pathname or `http(s)://` URL, or carries a query/fragment.
+ */
+export class InvalidIncludeValueError extends Error {
+	/**
+	 *
+	 * @param message
+	 */
+	constructor(message: string) {
+		super(message);
+		this.name = 'InvalidIncludeValueError';
+	}
+}
+
+/**
+ * Thrown by {@link filterUrlsByInclude} when one or more `--include` values
+ * matched zero pages. Thrown before any download or write so a typo fails
+ * loudly instead of silently migrating nothing for that value.
+ */
+export class IncludeNoMatchError extends Error {
+	/** Raw `--include` values (input order, not deduplicated) that matched no page. */
+	readonly unmatched: readonly string[];
+
+	/**
+	 *
+	 * @param unmatched
+	 */
+	constructor(unmatched: readonly string[]) {
+		super(
+			`--include matched no pages: ${unmatched.map((v) => JSON.stringify(v)).join(', ')}`,
+		);
+		this.name = 'IncludeNoMatchError';
+		this.unmatched = unmatched;
+	}
+}
+
+/**
+ * Parses a single `--include` raw value into an {@link IncludePattern}.
+ *
+ * `raw` must start with `/` (a pathname) or `http://` / `https://` (a full
+ * URL, whose host is ignored — only the pathname is used). Either form is run
+ * through `URL` so that non-ASCII segments percent-encode the same way page
+ * URLs do (both sides of the eventual comparison go through the same
+ * parser), and `.` / `..` segments resolve the same way a browser would.
+ *
+ * A trailing `/` marks the pattern as a directory-subtree prefix match
+ * (`isPrefix: true`); any other value is an exact-match single page. This
+ * rule has no exception for the root pattern: `--include /` or
+ * `--include https://example.com` both normalise to pathname `/`, which
+ * prefix-matches every page — i.e. equivalent to omitting `--include`
+ * entirely. That is intentional, not an error, so the rule stays uniform.
+ *
+ * Query strings and fragments are rejected rather than silently dropped:
+ * `--include /news/?p=1` looks like it targets one query variant, but
+ * pathname-only matching would make it match the entire `/news/` subtree.
+ *
+ * A value starting with `//` (protocol-relative, e.g. `//news/index.html`)
+ * is rejected rather than parsed as a pathname: per the URL spec, `new
+ * URL('//news/index.html', base)` treats `news` as a hostname and yields
+ * pathname `/index.html`, silently matching the wrong page instead of
+ * erroring.
+ * @param raw
+ * @example
+ * parseIncludePattern('/news/');
+ * // → { pathname: '/news/', isPrefix: true, raw: '/news/' }
+ * parseIncludePattern('https://example.com/about/index.html');
+ * // → { pathname: '/about/index.html', isPrefix: false, raw: '...' }
+ */
+export function parseIncludePattern(raw: string): IncludePattern {
+	let url: URL;
+	if (raw.startsWith('/') && !raw.startsWith('//')) {
+		url = new URL(raw, 'http://placeholder.invalid');
+	} else if (/^https?:\/\//.test(raw)) {
+		try {
+			url = new URL(raw);
+		} catch {
+			throw new InvalidIncludeValueError(
+				`--include value must start with "/" or "http(s)://": ${raw}`,
+			);
+		}
+	} else {
+		throw new InvalidIncludeValueError(
+			`--include value must start with "/" or "http(s)://": ${raw}`,
+		);
+	}
+
+	if (url.search !== '' || url.hash !== '') {
+		throw new InvalidIncludeValueError(
+			`--include does not support query/fragment: ${raw}`,
+		);
+	}
+
+	return { pathname: url.pathname, isPrefix: url.pathname.endsWith('/'), raw };
+}
+
+/**
+ * Returns whether `pathname` is selected by `pattern`. Prefix patterns always
+ * end with `/` (guaranteed by {@link parseIncludePattern}), so a plain
+ * `startsWith` cannot false-positive on a sibling directory (`/news/` never
+ * matches `/newsroom/`) and the directory's own index page (`/news/` itself)
+ * is included.
+ * @param pattern
+ * @param pathname
+ */
+function matchesPattern(pattern: IncludePattern, pathname: string): boolean {
+	return pattern.isPrefix
+		? pathname.startsWith(pattern.pathname)
+		: pathname === pattern.pathname;
+}
+
+/**
+ * Filters `urls` down to those selected by any of the `include` patterns
+ * (union). Every `include` value must match at least one URL — if any value
+ * matches zero pages, this throws {@link IncludeNoMatchError} listing every
+ * such value (not just the first) before the caller does any download or
+ * write. Values that fail to parse throw {@link InvalidIncludeValueError}
+ * first, ahead of matching.
+ *
+ * URLs in `urls` that fail to parse are treated as matching nothing (they are
+ * not filter-worthy, and this mirrors how they would already be reported as
+ * `failed` downstream when no filter is applied at all).
+ *
+ * An empty `include` selects every URL unchanged (no patterns to fail to
+ * match, so nothing is unmatched either) — the primitive itself encodes the
+ * "no filter" contract described on {@link import('./migrate.js').MigrateOptions.include},
+ * rather than relying on every caller to special-case it.
+ *
+ * The returned array preserves the input order of `urls` and contains no
+ * duplicates, even when a URL is selected by more than one pattern.
+ * @param include
+ * @param urls
+ * @example
+ * filterUrlsByInclude(
+ *   ['/news/'],
+ *   ['https://example.com/news/', 'https://example.com/news/a.html', 'https://example.com/about/'],
+ * );
+ * // → ['https://example.com/news/', 'https://example.com/news/a.html']
+ */
+export function filterUrlsByInclude(
+	include: readonly string[],
+	urls: readonly string[],
+): string[] {
+	if (include.length === 0) {
+		return [...urls];
+	}
+
+	const patterns = include.map((raw) => parseIncludePattern(raw));
+
+	const pathnameByUrl = new Map<string, string>();
+	for (const url of urls) {
+		try {
+			pathnameByUrl.set(url, new URL(url).pathname);
+		} catch {
+			// Unparsable URLs match nothing — see JSDoc above.
+		}
+	}
+
+	const matchCounts = new Map<IncludePattern, number>(
+		patterns.map((pattern) => [pattern, 0]),
+	);
+	const selected = new Set<string>();
+	for (const url of urls) {
+		const pathname = pathnameByUrl.get(url);
+		if (pathname === undefined) {
+			continue;
+		}
+		for (const pattern of patterns) {
+			if (matchesPattern(pattern, pathname)) {
+				matchCounts.set(pattern, matchCounts.get(pattern)! + 1);
+				selected.add(url);
+			}
+		}
+	}
+
+	const unmatched = patterns
+		.filter((pattern) => matchCounts.get(pattern) === 0)
+		.map((pattern) => pattern.raw);
+	if (unmatched.length > 0) {
+		throw new IncludeNoMatchError(unmatched);
+	}
+
+	return urls.filter((url) => selected.has(url));
+}

--- a/packages/@d-zero/site-migrator/src/index.ts
+++ b/packages/@d-zero/site-migrator/src/index.ts
@@ -46,6 +46,14 @@ export type {
 export { resolveIdTemplate } from './page-extractor/resolve-id-template.js';
 export type { ResolveIdTemplateOptions } from './page-extractor/resolve-id-template.js';
 
+export {
+	filterUrlsByInclude,
+	IncludeNoMatchError,
+	InvalidIncludeValueError,
+	parseIncludePattern,
+} from './include-filter.js';
+export type { IncludePattern } from './include-filter.js';
+
 export { migrate } from './migrate.js';
 export type { MigrateOptions, MigrateReport } from './migrate.js';
 

--- a/packages/@d-zero/site-migrator/src/migrate.spec.ts
+++ b/packages/@d-zero/site-migrator/src/migrate.spec.ts
@@ -6,6 +6,8 @@ import path from 'node:path';
 
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 
+import { IncludeNoMatchError, InvalidIncludeValueError } from './include-filter.js';
+
 vi.mock('./archive/open-archive.js', () => ({
 	openArchive: vi.fn(),
 }));
@@ -469,5 +471,180 @@ describe('migrate', () => {
 			}),
 		).rejects.toThrow('listing crashed');
 		expect(closeMock).toHaveBeenCalledTimes(1);
+	});
+
+	test('include filters pages while resources are still downloaded in full', async () => {
+		listInternalResourcesMock.mockReturnValue(
+			iter([
+				{ url: 'https://example.com/a.css', contentType: 'text/css' },
+				{ url: 'https://example.com/b.css', contentType: 'text/css' },
+			]),
+		);
+		listInternalPagesMock.mockReturnValue(
+			iter([
+				{ url: 'https://example.com/index.html' },
+				{ url: 'https://example.com/about/' },
+				{ url: 'https://example.com/about/team.html' },
+			]),
+		);
+		const fetchMock = vi.fn(() =>
+			Promise.resolve(new Response(new Uint8Array([1]), { status: 200 })),
+		);
+		vi.stubGlobal('fetch', fetchMock);
+		getPageHtmlMock.mockImplementation(() =>
+			Promise.resolve(
+				'<!doctype html><html><head></head><body><main><p>x</p></main></body></html>',
+			),
+		);
+
+		const report = await migrate({
+			archivePath: '/tmp/fake.nitpicker',
+			outputDir,
+			contentClass: CONTENT_CLASS,
+			include: ['/about/'],
+		});
+
+		expect(report).toMatchObject({ totalPages: 2, pagesExtracted: 2 });
+		// Resources are never filtered by `include` — both are still downloaded.
+		expect(fetchMock).toHaveBeenCalledTimes(2);
+		expect(getPageHtmlMock).toHaveBeenCalledTimes(2);
+		await expect(readFile(path.join(outputDir, 'index.html'))).rejects.toThrow();
+	});
+
+	test('include keeps ids identical to a full run and rewrites links to excluded pages to {{<id>}}', async () => {
+		listInternalResourcesMock.mockReturnValue(iter([]));
+		listInternalPagesMock.mockReturnValue(
+			iter([
+				{ url: 'https://example.com/index.html' },
+				{ url: 'https://example.com/about/' },
+			]),
+		);
+		vi.stubGlobal('fetch', vi.fn());
+		const indexInnerHtml = '<a href="/about/">about</a>';
+		getPageHtmlMock.mockResolvedValueOnce(
+			`<!doctype html><html><head></head><body><main>${indexInnerHtml}</main></body></html>`,
+		);
+		mockConvertedLayout({ 'https://example.com/index.html': indexInnerHtml });
+
+		await migrate({
+			archivePath: '/tmp/fake.nitpicker',
+			outputDir,
+			contentClass: CONTENT_CLASS,
+			include: ['/index.html'],
+		});
+
+		const written = await readFile(path.join(outputDir, 'index.html'), 'utf8');
+		// `/about/` was excluded by `include`, yet its id (subdir section 1 → 10000)
+		// is identical to an unfiltered run because the id population stays the
+		// full archive page list.
+		expect(written.startsWith(`---\nid: 5\n---\n<main class="${CONTENT_CLASS}">`)).toBe(
+			true,
+		);
+		expect(written).toContain('{{10000}}');
+		await expect(readFile(path.join(outputDir, 'about', 'index.html'))).rejects.toThrow();
+	});
+
+	test('include with no matching pages rejects before any download or write', async () => {
+		listInternalResourcesMock.mockReturnValue(
+			iter([{ url: 'https://example.com/a.css', contentType: 'text/css' }]),
+		);
+		listInternalPagesMock.mockReturnValue(
+			iter([{ url: 'https://example.com/index.html' }]),
+		);
+		const fetchMock = vi.fn();
+		vi.stubGlobal('fetch', fetchMock);
+
+		await expect(
+			migrate({
+				archivePath: '/tmp/fake.nitpicker',
+				outputDir,
+				contentClass: CONTENT_CLASS,
+				include: ['/nope/'],
+			}),
+		).rejects.toThrow(IncludeNoMatchError);
+		expect(fetchMock).not.toHaveBeenCalled();
+		expect(getPageHtmlMock).not.toHaveBeenCalled();
+		expect(closeMock).toHaveBeenCalledTimes(1);
+	});
+
+	test('include with an invalid value rejects before any download or write', async () => {
+		listInternalResourcesMock.mockReturnValue(iter([]));
+		listInternalPagesMock.mockReturnValue(
+			iter([{ url: 'https://example.com/index.html' }]),
+		);
+		const fetchMock = vi.fn();
+		vi.stubGlobal('fetch', fetchMock);
+
+		await expect(
+			migrate({
+				archivePath: '/tmp/fake.nitpicker',
+				outputDir,
+				contentClass: CONTENT_CLASS,
+				include: ['news/'],
+			}),
+		).rejects.toThrow(InvalidIncludeValueError);
+		expect(fetchMock).not.toHaveBeenCalled();
+		expect(getPageHtmlMock).not.toHaveBeenCalled();
+	});
+
+	test('an empty include array behaves as no filter', async () => {
+		listInternalResourcesMock.mockReturnValue(iter([]));
+		listInternalPagesMock.mockReturnValue(
+			iter([
+				{ url: 'https://example.com/index.html' },
+				{ url: 'https://example.com/about/' },
+			]),
+		);
+		vi.stubGlobal('fetch', vi.fn());
+		getPageHtmlMock.mockImplementation(() =>
+			Promise.resolve(
+				'<!doctype html><html><head></head><body><main><p>x</p></main></body></html>',
+			),
+		);
+
+		const report = await migrate({
+			archivePath: '/tmp/fake.nitpicker',
+			outputDir,
+			contentClass: CONTENT_CLASS,
+			include: [],
+		});
+
+		expect(report).toMatchObject({ totalPages: 2, pagesExtracted: 2 });
+	});
+
+	test('onInclude fires once with selected/total when include is given, and not at all otherwise', async () => {
+		listInternalResourcesMock.mockReturnValue(iter([]));
+		listInternalPagesMock.mockReturnValue(
+			iter([
+				{ url: 'https://example.com/index.html' },
+				{ url: 'https://example.com/about/' },
+				{ url: 'https://example.com/about/team.html' },
+			]),
+		);
+		vi.stubGlobal('fetch', vi.fn());
+		getPageHtmlMock.mockImplementation(() =>
+			Promise.resolve(
+				'<!doctype html><html><head></head><body><main><p>x</p></main></body></html>',
+			),
+		);
+
+		const events: unknown[] = [];
+		await migrate({
+			archivePath: '/tmp/fake.nitpicker',
+			outputDir,
+			contentClass: CONTENT_CLASS,
+			include: ['/about/'],
+			onInclude: (event) => events.push(event),
+		});
+		expect(events).toStrictEqual([{ selected: 2, total: 3 }]);
+
+		events.length = 0;
+		await migrate({
+			archivePath: '/tmp/fake.nitpicker',
+			outputDir,
+			contentClass: CONTENT_CLASS,
+			onInclude: (event) => events.push(event),
+		});
+		expect(events).toStrictEqual([]);
 	});
 });

--- a/packages/@d-zero/site-migrator/src/migrate.ts
+++ b/packages/@d-zero/site-migrator/src/migrate.ts
@@ -8,6 +8,7 @@ import { listInternalPages } from './archive/list-internal-pages.js';
 import { listInternalResources } from './archive/list-internal-resources.js';
 import { openArchive } from './archive/open-archive.js';
 import { downloadResources } from './downloader/download-resources.js';
+import { filterUrlsByInclude } from './include-filter.js';
 import { extractPages } from './page-extractor/extract-pages.js';
 
 export interface MigrateOptions {
@@ -30,6 +31,24 @@ export interface MigrateOptions {
 	downloadLimit?: number;
 	/** Maximum concurrent page extractions. Defaults to 10. */
 	extractLimit?: number;
+	/**
+	 * 移行対象ページを絞り込む`--include`生値のリスト（`/path`形式または
+	 * `http(s)://`URL）。各値はpathnameとして解釈され、末尾`/`はプレフィックス
+	 * 一致（ディレクトリ配下＋indexページ自身）、それ以外は完全一致
+	 * （{@link filterUrlsByInclude}参照）。省略時・空配列時は全ページが対象。
+	 * フィルタ対象は**ページのみ**で、リソースDLは常に全件（絞り込みによる
+	 * 参照切れリスクよりユーザーの明示選択を優先する設計判断）。形式不正の
+	 * 値は{@link import('./include-filter.js').InvalidIncludeValueError}、
+	 * 1ページもマッチしない値があれば
+	 * {@link import('./include-filter.js').IncludeNoMatchError}を、
+	 * DL・抽出を一切実行する前にthrowする。
+	 * id採番の母集合は常にアーカイブ全ページ
+	 * （{@link import('./page-extractor/extract-pages.js').ExtractPagesOptions.idUrls}参照）
+	 * のため、部分実行でもidと`{{<id>}}`参照は全体実行と一致する。
+	 */
+	include?: readonly string[];
+	/** `include`によるフィルタ適用直後（DL開始前）に1回だけ呼ばれる。`include`省略時は呼ばれない。 */
+	onInclude?: (event: { selected: number; total: number }) => void;
 	/**
 	 * Forwarded to both {@link downloadResources}（通常のリソースDL）と`extractPages`の
 	 * block内`download-file`アイテムの追加DL。後者は`MigrateReport`の`totalResources`/
@@ -100,6 +119,8 @@ export async function migrate(options: MigrateOptions): Promise<MigrateReport> {
 		layoutJsonPath,
 		downloadLimit,
 		extractLimit,
+		include,
+		onInclude,
 		onResource,
 		onPage,
 		signal,
@@ -115,6 +136,22 @@ export async function migrate(options: MigrateOptions): Promise<MigrateReport> {
 		const pageItems: ExtractPageItem[] = [];
 		for await (const page of listInternalPages(session)) {
 			pageItems.push({ url: page.url });
+		}
+
+		// --include filter: pages only. Runs BEFORE downloadResources so a
+		// no-match / invalid-value error aborts without downloading or writing
+		// anything. `allPageUrls` (the full archive page list, unfiltered)
+		// stays the id-numbering population passed to extractPages as
+		// `idUrls` below — unconditionally, whether or not `include` is set —
+		// so a partial run always assigns the same ids as a full run, and
+		// links to pages excluded by the filter still rewrite to `{{<id>}}`
+		// instead of silently falling back to a root-relative path.
+		const allPageUrls = pageItems.map((item) => item.url);
+		let selectedPageItems: ExtractPageItem[] = pageItems;
+		if (include !== undefined && include.length > 0) {
+			const selected = new Set(filterUrlsByInclude(include, allPageUrls));
+			selectedPageItems = pageItems.filter((item) => selected.has(item.url));
+			onInclude?.({ selected: selectedPageItems.length, total: pageItems.length });
 		}
 
 		// `totalResources`/`resourcesSaved`/`resourcesFailed` cover only this
@@ -161,7 +198,8 @@ export async function migrate(options: MigrateOptions): Promise<MigrateReport> {
 		let pagesBlockConversionFailed = 0;
 		await extractPages({
 			session,
-			items: pageItems,
+			items: selectedPageItems,
+			idUrls: allPageUrls,
 			outputDir,
 			contentClass,
 			layoutJsonPath,
@@ -222,7 +260,7 @@ export async function migrate(options: MigrateOptions): Promise<MigrateReport> {
 			totalResources,
 			resourcesSaved,
 			resourcesFailed,
-			totalPages: pageItems.length,
+			totalPages: selectedPageItems.length,
 			pagesExtracted,
 			pagesFallback,
 			pagesMissing,

--- a/packages/@d-zero/site-migrator/src/page-extractor/extract-pages.spec.ts
+++ b/packages/@d-zero/site-migrator/src/page-extractor/extract-pages.spec.ts
@@ -421,6 +421,64 @@ describe('extractPages', () => {
 		expect(written).not.toContain('href="/about/"');
 	});
 
+	test('idUrls widens the id map beyond items, so a link to an excluded page still resolves to {{<id>}}', async () => {
+		getPageHtmlMock.mockResolvedValueOnce(
+			docWith('<main><a href="/about/">about</a></main>'),
+		);
+		mockConvertedLayout('<a href="/about/">about</a>');
+
+		await extractPages({
+			session: FAKE_SESSION,
+			items: [{ url: 'https://example.com/index.html' }],
+			idUrls: ['https://example.com/index.html', 'https://example.com/about/'],
+			outputDir,
+			contentClass: CONTENT_CLASS,
+			limit: 1,
+		});
+
+		const written = await readFile(path.join(outputDir, 'index.html'), 'utf8');
+		expect(written.startsWith('---\nid: 5\n')).toBe(true);
+		expect(written).toContain('{{10000}}');
+	});
+
+	test('without idUrls, a link to a page absent from items falls back to a root-relative path (no id assigned)', async () => {
+		getPageHtmlMock.mockResolvedValueOnce(
+			docWith('<main><a href="/about/">about</a></main>'),
+		);
+		mockConvertedLayout('<a href="/about/">about</a>');
+
+		await extractPages({
+			session: FAKE_SESSION,
+			items: [{ url: 'https://example.com/index.html' }],
+			outputDir,
+			contentClass: CONTENT_CLASS,
+			limit: 1,
+		});
+
+		const written = await readFile(path.join(outputDir, 'index.html'), 'utf8');
+		expect(written).toContain('href="/about/"');
+		expect(written).not.toContain('{{');
+	});
+
+	test('a page URL absent from idUrls is still extracted, but written without a frontmatter block', async () => {
+		getPageHtmlMock.mockResolvedValueOnce(docWith('<main><p>x</p></main>'));
+
+		await extractPages({
+			session: FAKE_SESSION,
+			items: [{ url: 'https://example.com/orphan.html' }],
+			idUrls: ['https://example.com/other.html'],
+			outputDir,
+			contentClass: CONTENT_CLASS,
+			limit: 1,
+		});
+
+		const written = await readFile(path.join(outputDir, 'orphan.html'), 'utf8');
+		// No id (excluded from idUrls) and no DB row (default mock) → `buildFrontmatterBlock`
+		// emits no frontmatter block at all, not even an empty `---\n---\n`.
+		expect(written.startsWith('---')).toBe(false);
+		expect(written).toContain(`<main class="${CONTENT_CLASS}">`);
+	});
+
 	test('fail-soft on rewriteBlockRefs (wysiwyg→rewritePageRefs) throw: writes pre-rewrite HTML and surfaces an aggregate rewriteError on the outcome', async () => {
 		getPageHtmlMock.mockResolvedValueOnce(
 			docWith('<main><a href="/about/">about</a></main>'),

--- a/packages/@d-zero/site-migrator/src/page-extractor/extract-pages.ts
+++ b/packages/@d-zero/site-migrator/src/page-extractor/extract-pages.ts
@@ -50,6 +50,17 @@ export interface ExtractPagesOptions {
 	items: readonly ExtractPageItem[];
 	outputDir: string;
 	/**
+	 * {@link assignPageIds}の採番母集合となるURL一覧。省略時は`items`のURLから
+	 * 採番する（従来互換）。`items`のスーパーセットであること — 呼び出し側が
+	 * `items`を絞り込む場合（例: `migrate`の`include`オプション）でも、ここに
+	 * アーカイブの全ページURLを渡すことで部分実行時のidが全体実行時と一致し、
+	 * `items`に含まれないページへの`<a href>` / `<form action>`も
+	 * {@link rewritePageRefs} 経由で `{{<id>}}` に書き換わる。`items`に含まれない
+	 * URLは実際には抽出されないため、そのページ自身のfrontmatterは書き出されない
+	 * （idの割り当て先が存在しないだけで、副作用はない）。
+	 */
+	idUrls?: readonly string[];
+	/**
 	 * BurgerEditorの`editableArea`セレクタに対応させるクラス名。生成したブロック群を
 	 * 埋め込む既存main要素自身の`classList`に追加する（新規ラッパー要素は追加しない）。
 	 * 移行先サイトのBurgerEditor設定に依存する値であり、決め打ちのデフォルトを持たせると
@@ -225,6 +236,7 @@ export async function extractPages(options: ExtractPagesOptions): Promise<void> 
 		outputDir,
 		contentClass,
 		layoutJsonPath,
+		idUrls,
 		knownResourceUrls = new Set(),
 		limit = 10,
 		onResult,
@@ -276,12 +288,14 @@ export async function extractPages(options: ExtractPagesOptions): Promise<void> 
 	}
 	await Promise.all([...directories].map((dir) => mkdir(dir, { recursive: true })));
 
-	// Build the URL → id map up front from the full items list. Each page's id
-	// stays stable even when only a subset of pages succeeds, because the map
-	// is computed before any page worker runs. Build the pre-keyed lookup once
-	// alongside it so per-page rewritePageRefs calls don't pay an O(N²)
-	// rebuild.
-	const pageIds = assignPageIds(items.map((item) => item.url));
+	// Build the URL → id map up front from `idUrls` — the full archive page
+	// list when the caller filters `items` down to a subset (see
+	// MigrateOptions.include) — or, by default, from the full items list.
+	// Each page's id stays stable even when only a subset of pages runs or
+	// succeeds, because the map is computed from this invariant population
+	// before any page worker runs. Build the pre-keyed lookup once alongside
+	// it so per-page rewritePageRefs calls don't pay an O(N²) rebuild.
+	const pageIds = assignPageIds(idUrls ?? items.map((item) => item.url));
 	const pageIdLookup = buildPageIdLookup(pageIds);
 
 	// --- Fetch + extractMainContent + meta, per page, concurrent ---


### PR DESCRIPTION
## Summary

- Add a repeatable `--include <path>` option to `dz-migrate` so a subset of pages can be migrated instead of the whole archive
- `--include` values select pages by pathname: a trailing `/` matches a directory subtree (plus its index page), anything else matches a single page exactly; full `http(s)://` URLs are also accepted (host ignored)
- Resources are always downloaded in full regardless of `--include`
- Page id numbering always uses the full archive page list, so a filtered run assigns identical ids to a full run and links to excluded pages still rewrite to `{{<id>}}` instead of falling back to a root-relative path
- A value matching no page aborts with exit code 2 before any download or write, listing every unmatched value

## Test plan

- [x] `yarn lint` passes with no new errors
- [x] `yarn test` passes (354 tests, including 3 new/updated spec files: `include-filter.spec.ts`, `migrate.spec.ts`, `extract-pages.spec.ts`)
- [x] `yarn build` succeeds
- [x] Verified id stability: a filtered run (`include: ['/index.html']`) produces the same `id: 5` and rewrites a link to an excluded page to `{{10000}}`, matching an unfiltered run
- [x] Verified resources are downloaded in full even when pages are filtered
- [x] Verified no-match and invalid-value errors abort before any download/write

Closes #967
