### PR TITLE
fix(github): disable platformAutomerge for Renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,7 @@
 {
 	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
 	"configMigration": true,
+	"platformAutomerge": false,
 	"extends": [
 		"config:recommended",
 		"docker:pinDigests",


### PR DESCRIPTION
## 背景

このリポジトリのブランチ保護（`dev`）では `required_approving_review_count: 2` が設定されており、`bypass_pull_request_allowances` に Renovate app が登録されています。

先日、リポジトリ設定 `allow_auto_merge` を `false` から `true` に変更しましたが、これにより Renovate は「GitHub native auto-merge 予約」方式を使うようになりました。この方式はブランチ保護の `bypass_pull_request_allowances` を評価しないため、レビュー必須要件（本リポジトリは2件）を満たせず、CI 成功済みでも auto-merge 予約されたまま `mergeStateStatus: BLOCKED` で永久に詰まってしまうことが、他リポジトリ（kamado, linters）での検証で判明しました。

## 変更内容

`allow_auto_merge` の値に関わらず、Renovate が常に自前の direct マージ API（bypass が効く方式）を使うよう、`.github/renovate.json` のトップレベルに `"platformAutomerge": false` を明示的に設定しました。これにより、allow_auto_merge 有効化が bypass 機能と競合する問題を回避し、Renovate の automerge が正しく機能するようにします。

## 動作確認

- `yarn lint` / `yarn build` / `yarn test`（354 tests）すべて成功
- JSON構文を検証済み
