### PR TITLE
fix(site-migrator): resolve TS2345 by aligning puppeteer with anatomist

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -39,6 +39,12 @@
 			"matchUpdateTypes": ["minor", "patch", "pin", "digest"],
 			"matchCurrentVersion": "!/^0/",
 			"automerge": true
+		},
+		{
+			"description": "Group site-migrator puppeteer with @d-zero/anatomist so a version bump on either side prefers landing together in one PR — site-migrator launches puppeteer itself and passes the resulting Page across the package boundary into anatomist analyzePageLayout(), and the two must resolve the same puppeteer-core install or TypeScript rejects the Page argument as structurally incompatible (TS2345)",
+			"matchFileNames": ["packages/@d-zero/site-migrator/package.json"],
+			"matchDepNames": ["puppeteer", "@d-zero/anatomist"],
+			"groupName": "site-migrator puppeteer stack"
 		}
 	]
 }

--- a/packages/@d-zero/site-migrator/package.json
+++ b/packages/@d-zero/site-migrator/package.json
@@ -36,7 +36,7 @@
 	"dependencies": {
 		"@burger-editor/blocks": "^4.0.0-alpha.71",
 		"@burger-editor/core": "^4.0.0-alpha.71",
-		"@d-zero/anatomist": "^0.3.1",
+		"@d-zero/anatomist": "^0.3.2",
 		"@d-zero/dealer": "^1.10.4",
 		"@d-zero/shared": "^0.22.5",
 		"@nitpicker/crawler": "^0.18.0",
@@ -45,7 +45,7 @@
 		"jsdom": "30.0.1",
 		"parse5": "8.0.1",
 		"parse5-html-rewriting-stream": "8.0.1",
-		"puppeteer": "25.3.0"
+		"puppeteer": "25.5.0"
 	},
 	"devDependencies": {
 		"@types/js-yaml": "4.0.9",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1443,18 +1443,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@d-zero/anatomist@npm:^0.3.1":
-  version: 0.3.1
-  resolution: "@d-zero/anatomist@npm:0.3.1"
+"@d-zero/anatomist@npm:^0.3.2":
+  version: 0.3.2
+  resolution: "@d-zero/anatomist@npm:0.3.2"
   dependencies:
-    "@d-zero/beholder": "npm:4.2.2"
-    "@d-zero/dealer": "npm:1.10.4"
-    "@d-zero/puppeteer-page-scan": "npm:4.6.8"
-    "@d-zero/shared": "npm:0.22.5"
-    puppeteer: "npm:25.3.0"
+    "@d-zero/beholder": "npm:4.2.3"
+    "@d-zero/cli-core": "npm:1.4.0"
+    "@d-zero/dealer": "npm:1.11.0"
+    "@d-zero/puppeteer-page-scan": "npm:4.6.9"
+    "@d-zero/shared": "npm:0.23.0"
+    puppeteer: "npm:25.5.0"
   bin:
     anatomist: dist/cli.js
-  checksum: 10c0/adfaea602495ddda8a051a78fff44258fd7d4671b58404a39bf579898cea2de233642f5db78014d1af1ef3055618b5228d10ca5c7c33fee670e2f95180976190
+  checksum: 10c0/5a44b3e21c5c8409458f16a4284000dc7583d4773db6456eeb62cf49de40e239b01b7f8393acd036216e6c19a6634bdac2790865dfd2193e6d11670f66878be8
   languageName: node
   linkType: hard
 
@@ -1471,6 +1472,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@d-zero/beholder@npm:4.2.3":
+  version: 4.2.3
+  resolution: "@d-zero/beholder@npm:4.2.3"
+  dependencies:
+    "@d-zero/puppeteer-page-scan": "npm:4.6.9"
+    "@d-zero/shared": "npm:0.23.0"
+    debug: "npm:4.4.3"
+    puppeteer: "npm:25.5.0"
+    simple-wappalyzer: "npm:1.1.100"
+  checksum: 10c0/83fb2c087d75f11056519228e8bee9bd4a3dda4b96c162d0f1989babb44fe85a917cc6d27590b70cbdb3dbe1912d66fc40170911878fd3d68cbb118c77890165
+  languageName: node
+  linkType: hard
+
 "@d-zero/check-frontend-env@workspace:packages/@d-zero/check-frontend-env":
   version: 0.0.0-use.local
   resolution: "@d-zero/check-frontend-env@workspace:packages/@d-zero/check-frontend-env"
@@ -1478,6 +1492,16 @@ __metadata:
     check-frontend-env: ./dist/index.js
   languageName: unknown
   linkType: soft
+
+"@d-zero/cli-core@npm:1.4.0":
+  version: 1.4.0
+  resolution: "@d-zero/cli-core@npm:1.4.0"
+  dependencies:
+    "@d-zero/shared": "npm:0.23.0"
+    minimist: "npm:1.2.8"
+  checksum: 10c0/ad3f7ad8b4f90b5eee07d15503495016d2a28df1e5364e3b5bce26683fd2374dcdc70223d288a35cd36da0f2f2736262d3118ec30761af5ebde6576d7e3eaa67
+  languageName: node
+  linkType: hard
 
 "@d-zero/commitlint-config@npm:^5.1.0":
   version: 5.1.0
@@ -1560,6 +1584,16 @@ __metadata:
     "@d-zero/shared": "npm:0.22.5"
     ansi-colors: "npm:4.1.3"
   checksum: 10c0/6d85dc7b7f810c12be96ce2683c730cd7a41206991f7941afaf9c4d1b50911f676e58a57609759de447a173dc32c6ec58b4e20a471f77a1cb3ca469d3e8018c3
+  languageName: node
+  linkType: hard
+
+"@d-zero/dealer@npm:1.11.0":
+  version: 1.11.0
+  resolution: "@d-zero/dealer@npm:1.11.0"
+  dependencies:
+    "@d-zero/shared": "npm:0.23.0"
+    ansi-colors: "npm:4.1.3"
+  checksum: 10c0/398f0e03f97dea3b8e6bf24b1cc3e08e3a71b0b62be6f6f8b9e5347229505d85c526a13230106dc69619cc9e344287e66d53f703a8c58c97365b99d7b212a6f2
   languageName: node
   linkType: hard
 
@@ -1687,6 +1721,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@d-zero/puppeteer-general-actions@npm:1.2.7":
+  version: 1.2.7
+  resolution: "@d-zero/puppeteer-general-actions@npm:1.2.7"
+  dependencies:
+    ansi-colors: "npm:4.1.3"
+  checksum: 10c0/2c6d96e1a6f94a6eff5ad0792b9c6df2e71d79d12efb902d9941df428acccfa287e766ca44e0586b7207feacfbbd4cc23949569b6f3f3bcb55d03c04cdd3ff87
+  languageName: node
+  linkType: hard
+
 "@d-zero/puppeteer-page-scan@npm:4.6.8":
   version: 4.6.8
   resolution: "@d-zero/puppeteer-page-scan@npm:4.6.8"
@@ -1700,6 +1743,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@d-zero/puppeteer-page-scan@npm:4.6.9":
+  version: 4.6.9
+  resolution: "@d-zero/puppeteer-page-scan@npm:4.6.9"
+  dependencies:
+    "@d-zero/puppeteer-general-actions": "npm:1.2.7"
+    "@d-zero/puppeteer-scroll": "npm:4.0.12"
+    "@d-zero/shared": "npm:0.23.0"
+  peerDependencies:
+    puppeteer: 25.5.0
+  checksum: 10c0/b335cb6633dd8b75e5baa0e533f795d890fbefeb05480b0339cc786312c1d0d96c3f1554cf3c5b109b1693e9613276aff3ef4a498b9292a853fc0d712093f8a3
+  languageName: node
+  linkType: hard
+
 "@d-zero/puppeteer-scroll@npm:4.0.11":
   version: 4.0.11
   resolution: "@d-zero/puppeteer-scroll@npm:4.0.11"
@@ -1708,6 +1764,17 @@ __metadata:
   peerDependencies:
     puppeteer: 25.2.1
   checksum: 10c0/67b25868ee844dcebc11aa408307d21dc9f4b2fbfeca1a26d80558763fb8aefba7312fb9b9fcf2a38d3148b35fb83537c7db5426f2fa137518a9f3c6fcfda270
+  languageName: node
+  linkType: hard
+
+"@d-zero/puppeteer-scroll@npm:4.0.12":
+  version: 4.0.12
+  resolution: "@d-zero/puppeteer-scroll@npm:4.0.12"
+  dependencies:
+    "@d-zero/shared": "npm:0.23.0"
+  peerDependencies:
+    puppeteer: 25.5.0
+  checksum: 10c0/02a1b8a57a9af85bbc09a2effca0e4dade25ae74d6d2f0c1d94b34ae55361f59f675cee3ed34152122cdc88501993b7805264d2d3a1fad123b80131683d8e9d1
   languageName: node
   linkType: hard
 
@@ -1787,13 +1854,28 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@d-zero/shared@npm:0.23.0":
+  version: 0.23.0
+  resolution: "@d-zero/shared@npm:0.23.0"
+  dependencies:
+    "@holiday-jp/holiday_jp": "npm:2.5.1"
+    await-event-emitter: "npm:2.0.2"
+    dayjs: "npm:1.11.21"
+    escape-string-regexp: "npm:5.0.0"
+    front-matter: "npm:4.0.2"
+    micromatch: "npm:4.0.8"
+    sanitize-filename: "npm:1.6.4"
+  checksum: 10c0/56a4e76c117d5918a2a0dfa34daf75138812db1349217d89cf65ee329ab2f2f7a9be4c9241a80fcc8ab732254f233b0381776e8fa4e4e9b96e630bba5d2ccd55
+  languageName: node
+  linkType: hard
+
 "@d-zero/site-migrator@workspace:packages/@d-zero/site-migrator":
   version: 0.0.0-use.local
   resolution: "@d-zero/site-migrator@workspace:packages/@d-zero/site-migrator"
   dependencies:
     "@burger-editor/blocks": "npm:^4.0.0-alpha.71"
     "@burger-editor/core": "npm:^4.0.0-alpha.71"
-    "@d-zero/anatomist": "npm:^0.3.1"
+    "@d-zero/anatomist": "npm:^0.3.2"
     "@d-zero/dealer": "npm:^1.10.4"
     "@d-zero/shared": "npm:^0.22.5"
     "@nitpicker/crawler": "npm:^0.18.0"
@@ -1805,7 +1887,7 @@ __metadata:
     jsdom: "npm:30.0.1"
     parse5: "npm:8.0.1"
     parse5-html-rewriting-stream: "npm:8.0.1"
-    puppeteer: "npm:25.3.0"
+    puppeteer: "npm:25.5.0"
   bin:
     dz-migrate: dist/cli.js
   languageName: unknown
@@ -4384,6 +4466,26 @@ __metadata:
   bin:
     browsers: lib/main-cli.js
   checksum: 10c0/145c9136b6a4a2de0a1a6413ab92eb791384a8d103dea253a487eacaaabc66927205dbe843f899dfb961fb0fddc164e17ad6fbad83bc40ff39513a0a0b51172a
+  languageName: node
+  linkType: hard
+
+"@puppeteer/browsers@npm:3.1.0":
+  version: 3.1.0
+  resolution: "@puppeteer/browsers@npm:3.1.0"
+  dependencies:
+    modern-tar: "npm:^0.7.6"
+    yargs: "npm:^18.0.0"
+  peerDependencies:
+    proxy-agent: ">=8.0.1"
+    yauzl: ^2.10.0 || ^3.4.0
+  peerDependenciesMeta:
+    proxy-agent:
+      optional: true
+    yauzl:
+      optional: true
+  bin:
+    browsers: lib/main-cli.js
+  checksum: 10c0/cab18c02f6e77a8d261a08a062c3cebd1227666d425f3731bc91cd001331beeaf165046bc20d3d25dc1eaf5869a6d9f4f8fc5d3d76f1dace28d79b616846291f
   languageName: node
   linkType: hard
 
@@ -7683,6 +7785,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"chromium-bidi@npm:17.0.2":
+  version: 17.0.2
+  resolution: "chromium-bidi@npm:17.0.2"
+  dependencies:
+    mitt: "npm:^3.0.1"
+    zod: "npm:^3.24.1"
+  peerDependencies:
+    devtools-protocol: "*"
+  checksum: 10c0/cc1fcbdf2309f2f0083096c78a299342918c6dc8e80158487aada8e2ee73160ed7301bb54c5520274e4514f2a14f05e45d730a536e0a95f2e204dd8bf42eebee
+  languageName: node
+  linkType: hard
+
 "chrono-node@npm:2.8.4":
   version: 2.8.4
   resolution: "chrono-node@npm:2.8.4"
@@ -9064,6 +9178,13 @@ __metadata:
   version: 0.0.1638949
   resolution: "devtools-protocol@npm:0.0.1638949"
   checksum: 10c0/68aab193628a6a9c06487c1d68f39a106f50e3f83784a8767ee8d703a1f1fde4f055a59f239bda3a0bb76941fecf1da3122d3b66b81b5ea36dc0532223479c79
+  languageName: node
+  linkType: hard
+
+"devtools-protocol@npm:0.0.1653615":
+  version: 0.0.1653615
+  resolution: "devtools-protocol@npm:0.0.1653615"
+  checksum: 10c0/2a8e63aac7fb7ee4a7eef0e75bf17b7f03f44f085c79ac4e2c53b82e86f908094c1d1b2a0f85f2a7742b3d420e5a3ff8e522bca3dc609c98850239dbd2ce5428
   languageName: node
   linkType: hard
 
@@ -16831,6 +16952,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"puppeteer-core@npm:25.5.0":
+  version: 25.5.0
+  resolution: "puppeteer-core@npm:25.5.0"
+  dependencies:
+    "@puppeteer/browsers": "npm:3.1.0"
+    chromium-bidi: "npm:17.0.2"
+    devtools-protocol: "npm:0.0.1653615"
+    typed-query-selector: "npm:^2.12.2"
+    webdriver-bidi-protocol: "npm:0.4.2"
+    ws: "npm:^8.21.1"
+  checksum: 10c0/137132e4977ac9aa77c6ddbfb12a9412f3c67a312381800b85a602cabbe3a3659fe41c64ee8c5ab42d3793ba8933987145e7ba06d85999cae406446b3fcb077a
+  languageName: node
+  linkType: hard
+
 "puppeteer@npm:25.3.0":
   version: 25.3.0
   resolution: "puppeteer@npm:25.3.0"
@@ -16844,6 +16979,22 @@ __metadata:
   bin:
     puppeteer: lib/puppeteer/node/cli.js
   checksum: 10c0/0c4a52dad12f30f8d7f90f2f8cde3cff686b0d496d482cedd5206a9fb40af38b958ab33f4ff4e086af0937a5af011ba4351bd556cc07924af208edbcdaf96fc2
+  languageName: node
+  linkType: hard
+
+"puppeteer@npm:25.5.0":
+  version: 25.5.0
+  resolution: "puppeteer@npm:25.5.0"
+  dependencies:
+    "@puppeteer/browsers": "npm:3.1.0"
+    chromium-bidi: "npm:17.0.2"
+    devtools-protocol: "npm:0.0.1653615"
+    lilconfig: "npm:^3.1.3"
+    puppeteer-core: "npm:25.5.0"
+    typed-query-selector: "npm:^2.12.2"
+  bin:
+    puppeteer: lib/puppeteer/node/cli.js
+  checksum: 10c0/c331e7ecb1f6c3f675490ba793307b5f6f7c7c0ef748f65717fe01bae0b9804d29c39c2cffc00f2857e4ed6939f5f916bf917bd465b260675c0ddc114f87def7
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- Fixes the TS2345 build failure caused by Renovate PR #997 (`puppeteer` 25.3.0 → 25.5.0 in `@d-zero/site-migrator`)
- `site-migrator` launches `puppeteer` itself and passes the resulting `Page` across the package boundary into `@d-zero/anatomist`'s `analyzePageLayout()`. Bumping `site-migrator`'s own `puppeteer` without also bumping `@d-zero/anatomist` left the two packages resolving different `puppeteer-core` installs, so TypeScript rejected the `Page` argument as structurally incompatible.
- `@d-zero/anatomist` 0.3.2 already tracks `puppeteer` 25.5.0, so bumping `site-migrator`'s dependency on it (`^0.3.1` → `^0.3.2`) resolves both packages to the same `puppeteer-core` install.
- Added a Renovate `packageRules` entry grouping `puppeteer` and `@d-zero/anatomist` within `site-migrator`'s `package.json`, so that when both have pending updates they land in one PR instead of drifting apart again.

## Not in scope

- A runtime fail-fast check (asserting both packages resolve the same puppeteer-core install) was considered and intentionally not added: the TS2345 build-time type check already catches this drift (this PR's root cause is exactly that check firing), and `site-migrator` ships as a self-contained CLI with its own locked dependency tree, so the added value of a duplicate runtime check was judged too low for the maintenance cost.
- The true structural fix — `@d-zero/anatomist` declaring `puppeteer` as a `peerDependency` instead of a direct `dependency` — belongs to that package's own repository and is out of scope here.
- Renovate PR #997 itself is left untouched; it should auto-close once this PR merges and resolves to the same puppeteer version.

## Test plan

- [x] `yarn build` — passes
- [x] `yarn test` — 357 tests pass
- [x] `yarn lint` — 0 errors (pre-existing warnings only, unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
