### PR TITLE
fix(site-migrator): adapt YAML frontmatter dump to js-yaml v5

### DIFF
--- a/packages/@d-zero/site-migrator/package.json
+++ b/packages/@d-zero/site-migrator/package.json
@@ -41,14 +41,13 @@
 		"@d-zero/shared": "^0.22.5",
 		"@nitpicker/crawler": "^0.18.0",
 		"@nitpicker/query": "^0.18.0",
-		"js-yaml": "4.3.1",
+		"js-yaml": "5.2.3",
 		"jsdom": "30.0.1",
 		"parse5": "8.0.1",
 		"parse5-html-rewriting-stream": "8.0.1",
 		"puppeteer": "25.5.0"
 	},
 	"devDependencies": {
-		"@types/js-yaml": "4.0.9",
 		"@types/jsdom": "30.0.0",
 		"@types/node": "25.9.5"
 	}

--- a/packages/@d-zero/site-migrator/src/html/format-frontmatter.ts
+++ b/packages/@d-zero/site-migrator/src/html/format-frontmatter.ts
@@ -1,6 +1,6 @@
 import type { Frontmatter, OgFrontmatter, TwitterFrontmatter } from '../types.js';
 
-import { dump } from 'js-yaml';
+import { dump, strTag, visit } from 'js-yaml';
 
 /**
  * Serialises a {@link Frontmatter} to the `---\n…\n---\n` YAML frontmatter
@@ -27,15 +27,22 @@ export function formatFrontmatter(meta: Frontmatter): string {
 		return '';
 	}
 	const yaml = dump(ordered, {
-		forceQuotes: true,
-		// js-yaml picks single quotes by default; pin to double to match the
-		// downstream scaffold pipeline's serialisation expectations.
-		quotingType: '"',
 		lineWidth: -1,
 		indent: 2,
 		// `noRefs` avoids `*ref0` / `&ref0` anchors when the same string instance
 		// appears in two slots (rawTitle / title etc.).
 		noRefs: true,
+		// js-yaml's `forceQuotes` also quotes non-string scalars (e.g. `id`),
+		// tagging them `!!int "42"` to preserve their type through the quotes.
+		// Force double quotes on string values only, leaving numbers bare, to
+		// match the downstream scaffold pipeline's serialisation expectations.
+		transform: (documents) => {
+			visit(documents, (node, ctx) => {
+				if (node.kind === 'scalar' && node.tag === strTag.tagName && !ctx.isKey) {
+					node.style.doubleQuoted = true;
+				}
+			});
+		},
 	});
 	return `---\n${yaml}---\n`;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1880,10 +1880,9 @@ __metadata:
     "@d-zero/shared": "npm:^0.22.5"
     "@nitpicker/crawler": "npm:^0.18.0"
     "@nitpicker/query": "npm:^0.18.0"
-    "@types/js-yaml": "npm:4.0.9"
     "@types/jsdom": "npm:30.0.0"
     "@types/node": "npm:25.9.5"
-    js-yaml: "npm:4.3.1"
+    js-yaml: "npm:5.2.3"
     jsdom: "npm:30.0.1"
     parse5: "npm:8.0.1"
     parse5-html-rewriting-stream: "npm:8.0.1"
@@ -5808,13 +5807,6 @@ __metadata:
     "@types/through": "npm:*"
     rxjs: "npm:^7.2.0"
   checksum: 10c0/235a02a3afa5b238ca9093ef7064e17d763ba134b1afd5a263ffc363ccdb6d1f7d64aa3866ca93e7ad52be4ff21324368a983d20d35caf21c16475cfb32db8c8
-  languageName: node
-  linkType: hard
-
-"@types/js-yaml@npm:4.0.9":
-  version: 4.0.9
-  resolution: "@types/js-yaml@npm:4.0.9"
-  checksum: 10c0/24de857aa8d61526bbfbbaa383aa538283ad17363fcd5bb5148e2c7f604547db36646440e739d78241ed008702a8920665d1add5618687b6743858fae00da211
   languageName: node
   linkType: hard
 
@@ -12505,14 +12497,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"js-yaml@npm:4.3.1":
-  version: 4.3.1
-  resolution: "js-yaml@npm:4.3.1"
+"js-yaml@npm:5.2.3":
+  version: 5.2.3
+  resolution: "js-yaml@npm:5.2.3"
   dependencies:
     argparse: "npm:^2.0.1"
   bin:
-    js-yaml: bin/js-yaml.js
-  checksum: 10c0/13c500ca322e0c3f8c81686e6ecda96d2ea37b45247a420c17c7db36932d6965cc27391abc2d1a104501600e7f0d947a5f8b7be6db619c4fefa87901b3512807
+    js-yaml: bin/js-yaml.mjs
+  checksum: 10c0/55cd6310c8eee88d432ae038d451ac9d6aa0eb9e5d38a94df3d6c4a4015d08c9dad7c18669e0e8854e4173a615d6b6b7448bd0aac408773f8a46122ffd863c69
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- `@d-zero/site-migrator`'s TypeScript build fails once `js-yaml` is bumped to v5 (see #1006): `DumpOptions` no longer has `quotingType`, since js-yaml v5 replaced it with `quoteStyle` and additionally made `forceQuotes` tag-and-quote non-string scalars (e.g. `id: !!int "42"`) to preserve their type.
- Bump `js-yaml` to `5.2.3` and rework `formatFrontmatter`'s dump options to use a `transform`/`visit` callback that force-double-quotes string scalars only, leaving numbers (the `id` field) bare — matching the previous v4 output exactly.
- Drop `@types/js-yaml`, which is no longer needed since js-yaml v5 ships its own type definitions.

## Test plan

- [x] `yarn build` — TypeScript build passes across all packages
- [x] `yarn test` — 28 test files / 357 tests pass, including all 11 `format-frontmatter.spec.ts` cases (bare integer `id`, forced double quotes, special-character escaping, no line wrapping, nested `og`/`twitter` maps)
- [x] `yarn lint` — no new errors (pre-existing warnings only, unrelated to this change)
