### PR TITLE
fix(scaffold): sandbox skills:sync tmp dir under project root

### DIFF
--- a/packages/@d-zero/create-frontend/index.spec.js
+++ b/packages/@d-zero/create-frontend/index.spec.js
@@ -164,6 +164,16 @@ describe('CLI', () => {
 			const pkg = JSON.parse(fs.readFileSync(path.join(dir, 'package.json'), 'utf8'));
 			expect(pkg.dependencies['jquery']).toBe('3.7.1');
 		});
+
+		test('static: skills:sync がプロジェクト配下の一時ディレクトリ(.tmp)を使用する', async ({
+			tmpDir,
+			task,
+		}) => {
+			const dir = path.join(tmpDir, getName(task));
+			await interactiveTest(dir, 'static');
+			const pkg = JSON.parse(fs.readFileSync(path.join(dir, 'package.json'), 'utf8'));
+			expect(pkg.scripts['skills:sync']).toContain('TMPDIR=./.tmp');
+		});
 	});
 
 	describe('flake.nix', () => {

--- a/packages/@d-zero/scaffold/.gitignore
+++ b/packages/@d-zero/scaffold/.gitignore
@@ -24,6 +24,7 @@ yarn-error.log
 .11ty
 .serve
 .cache
+.tmp
 
 # Tools
 .print

--- a/packages/@d-zero/scaffold/package.json
+++ b/packages/@d-zero/scaffold/package.json
@@ -35,7 +35,7 @@
 		"test": "vitest run",
 		"bge": "npx @burger-editor/local",
 		"print": "npx @d-zero/print -f __info/print.txt --type note",
-		"skills:sync": "npx skills add https://github.com/d-zero-dev/frontend-guidelines/tree/main/skills --skill '*' --agent claude-code --copy -y",
+		"skills:sync": "mkdir -p .tmp && TMPDIR=./.tmp npx skills add https://github.com/d-zero-dev/frontend-guidelines/tree/main/skills --skill '*' --agent claude-code --copy -y",
 		"update": "yarn upgrade-interactive"
 	},
 	"browserslist": [


### PR DESCRIPTION
## Summary
- Route `skills:sync`'s `TMPDIR` to a project-local `./.tmp` directory so `npx skills add` resolves the pinned `devDependencies["skills"]` binary instead of failing in sandboxes where the OS temp dir is unwritable/out of scope
- Add `.tmp` to the scaffold's `.gitignore` (propagates to generated projects) as a defensive measure against leftover files if the sync is interrupted
- Add a regression test asserting the generated project's `package.json` `skills:sync` script uses the project-local tmp dir

## Test plan
- [x] `yarn lint`
- [x] `yarn build`
- [x] `yarn test` (361 passed, including the new regression test)

Closes #1054
