### PR TITLE
fix(scaffold): ignore .claude/settings.local.json

### DIFF
--- a/packages/@d-zero/scaffold/.gitignore
+++ b/packages/@d-zero/scaffold/.gitignore
@@ -4,6 +4,7 @@ npm-error.log
 yarn-error.log
 .env
 .husky/_/*
+.claude/settings.local.json
 .yarn/install-state.gz
 .yarn/build-state.yml
 .direnv


### PR DESCRIPTION
## Summary

- Add `.claude/settings.local.json` to the scaffold's `.gitignore` template so this personal-environment file is excluded from newly scaffolded projects.

Closes #1055

## Test plan

- [x] `yarn lint`
- [x] `yarn build`
- [x] `yarn test`
